### PR TITLE
fix: eth fee filter

### DIFF
--- a/src/app/_components/operators/filters/eth-fee-filter.tsx
+++ b/src/app/_components/operators/filters/eth-fee-filter.tsx
@@ -46,8 +46,8 @@ export function EthFeeFilter() {
         defaultRange={defaultRange}
         apply={apply}
         remove={remove}
-        step={0.01}
-        decimals={2}
+        step={0.0001}
+        decimals={4}
         inputs={{
           start: {
             rightSlot: (

--- a/src/lib/abi/setter.ts
+++ b/src/lib/abi/setter.ts
@@ -17,12 +17,12 @@ export const SETTER_ABI = [
   },
   {
     inputs: [],
-    name: "ApprovalNotWithinTimeframe",
+    name: "AlreadyVoted",
     type: "error",
   },
   {
     inputs: [],
-    name: "CallerNotOwner",
+    name: "ApprovalNotWithinTimeframe",
     type: "error",
   },
   {
@@ -39,11 +39,6 @@ export const SETTER_ABI = [
       },
     ],
     name: "CallerNotOwnerWithData",
-    type: "error",
-  },
-  {
-    inputs: [],
-    name: "CallerNotWhitelisted",
     type: "error",
   },
   {
@@ -64,7 +59,7 @@ export const SETTER_ABI = [
   },
   {
     inputs: [],
-    name: "ClusterDoesNotExists",
+    name: "ClusterDoesNotExist",
     type: "error",
   },
   {
@@ -79,18 +74,22 @@ export const SETTER_ABI = [
   },
   {
     inputs: [],
-    name: "EmptyPublicKeysList",
+    name: "EBBelowMinimum",
     type: "error",
   },
   {
-    inputs: [
-      {
-        internalType: "uint64",
-        name: "operatorId",
-        type: "uint64",
-      },
-    ],
-    name: "ExceedValidatorLimit",
+    inputs: [],
+    name: "EBExceedsMaximum",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ETHTransferFailed",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "EmptyPublicKeysList",
     type: "error",
   },
   {
@@ -126,12 +125,28 @@ export const SETTER_ABI = [
   },
   {
     inputs: [],
+    name: "FutureBlockNumber",
+    type: "error",
+  },
+  {
+    inputs: [],
     name: "IncorrectClusterState",
     type: "error",
   },
   {
     inputs: [],
-    name: "IncorrectValidatorState",
+    name: "IncorrectClusterVersion",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint8",
+        name: "operatorVersion",
+        type: "uint8",
+      },
+    ],
+    name: "IncorrectOperatorVersion",
     type: "error",
   },
   {
@@ -162,7 +177,22 @@ export const SETTER_ABI = [
   },
   {
     inputs: [],
+    name: "InvalidProof",
+    type: "error",
+  },
+  {
+    inputs: [],
     name: "InvalidPublicKeyLength",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidQuorum",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidToken",
     type: "error",
   },
   {
@@ -179,6 +209,26 @@ export const SETTER_ABI = [
       },
     ],
     name: "InvalidWhitelistingContract",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "LegacyOperatorFeeDeclarationInvalid",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "MaxPrecisionExceeded",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "MaxRequestsAmountReached",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "MaxValueExceeded",
     type: "error",
   },
   {
@@ -203,6 +253,26 @@ export const SETTER_ABI = [
   },
   {
     inputs: [],
+    name: "NotCSSV",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "NotOracle",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "NothingToClaim",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "NothingToWithdraw",
+    type: "error",
+  },
+  {
+    inputs: [],
     name: "OperatorAlreadyExists",
     type: "error",
   },
@@ -218,7 +288,22 @@ export const SETTER_ABI = [
   },
   {
     inputs: [],
+    name: "OracleAlreadyAssigned",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "OracleHasZeroWeight",
+    type: "error",
+  },
+  {
+    inputs: [],
     name: "PublicKeysSharesLengthMismatch",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "RootNotFound",
     type: "error",
   },
   {
@@ -228,7 +313,17 @@ export const SETTER_ABI = [
   },
   {
     inputs: [],
-    name: "TargetModuleDoesNotExist",
+    name: "StakeTooLow",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "StaleBlockNumber",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "StaleUpdate",
     type: "error",
   },
   {
@@ -254,7 +349,12 @@ export const SETTER_ABI = [
   },
   {
     inputs: [],
-    name: "ValidatorAlreadyExists",
+    name: "UnstakeAmountExceedsBalance",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "UpdateTooFrequent",
     type: "error",
   },
   {
@@ -275,7 +375,17 @@ export const SETTER_ABI = [
   },
   {
     inputs: [],
+    name: "ZeroAddress",
+    type: "error",
+  },
+  {
+    inputs: [],
     name: "ZeroAddressNotAllowed",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ZeroAmount",
     type: "error",
   },
   {
@@ -308,6 +418,70 @@ export const SETTER_ABI = [
       },
     ],
     name: "BeaconUpgraded",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "owner",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint64[]",
+        name: "operatorIds",
+        type: "uint64[]",
+      },
+      {
+        indexed: true,
+        internalType: "uint64",
+        name: "blockNum",
+        type: "uint64",
+      },
+      {
+        indexed: false,
+        internalType: "uint32",
+        name: "effectiveBalance",
+        type: "uint32",
+      },
+      {
+        components: [
+          {
+            internalType: "uint32",
+            name: "validatorCount",
+            type: "uint32",
+          },
+          {
+            internalType: "uint64",
+            name: "networkFeeIndex",
+            type: "uint64",
+          },
+          {
+            internalType: "uint64",
+            name: "index",
+            type: "uint64",
+          },
+          {
+            internalType: "bool",
+            name: "active",
+            type: "bool",
+          },
+          {
+            internalType: "uint256",
+            name: "balance",
+            type: "uint256",
+          },
+        ],
+        indexed: false,
+        internalType: "struct ISSVNetworkCore.Cluster",
+        name: "cluster",
+        type: "tuple",
+      },
+    ],
+    name: "ClusterBalanceUpdated",
     type: "event",
   },
   {
@@ -436,6 +610,76 @@ export const SETTER_ABI = [
         type: "uint64[]",
       },
       {
+        indexed: false,
+        internalType: "uint256",
+        name: "ethDeposited",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "ssvRefunded",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint32",
+        name: "effectiveBalance",
+        type: "uint32",
+      },
+      {
+        components: [
+          {
+            internalType: "uint32",
+            name: "validatorCount",
+            type: "uint32",
+          },
+          {
+            internalType: "uint64",
+            name: "networkFeeIndex",
+            type: "uint64",
+          },
+          {
+            internalType: "uint64",
+            name: "index",
+            type: "uint64",
+          },
+          {
+            internalType: "bool",
+            name: "active",
+            type: "bool",
+          },
+          {
+            internalType: "uint256",
+            name: "balance",
+            type: "uint256",
+          },
+        ],
+        indexed: false,
+        internalType: "struct ISSVNetworkCore.Cluster",
+        name: "cluster",
+        type: "tuple",
+      },
+    ],
+    name: "ClusterMigratedToETH",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "owner",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint64[]",
+        name: "operatorIds",
+        type: "uint64[]",
+      },
+      {
         components: [
           {
             internalType: "uint32",
@@ -536,11 +780,49 @@ export const SETTER_ABI = [
       {
         indexed: false,
         internalType: "uint64",
+        name: "newCooldownDuration",
+        type: "uint64",
+      },
+    ],
+    name: "CooldownDurationUpdated",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint64",
         name: "value",
         type: "uint64",
       },
     ],
     name: "DeclareOperatorFeePeriodUpdated",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "token",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "ERC20Rescued",
     type: "event",
   },
   {
@@ -580,12 +862,44 @@ export const SETTER_ABI = [
     inputs: [
       {
         indexed: false,
+        internalType: "uint256",
+        name: "newFeesWei",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "accEthPerShare",
+        type: "uint256",
+      },
+    ],
+    name: "FeesSynced",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
         internalType: "uint8",
         name: "version",
         type: "uint8",
       },
     ],
     name: "Initialized",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint64",
+        name: "value",
+        type: "uint64",
+      },
+    ],
+    name: "LiquidationThresholdPeriodSSVUpdated",
     type: "event",
   },
   {
@@ -611,7 +925,33 @@ export const SETTER_ABI = [
         type: "uint256",
       },
     ],
+    name: "MinimumLiquidationCollateralSSVUpdated",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "value",
+        type: "uint256",
+      },
+    ],
     name: "MinimumLiquidationCollateralUpdated",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "minFee",
+        type: "uint256",
+      },
+    ],
+    name: "MinimumOperatorEthFeeUpdated",
     type: "event",
   },
   {
@@ -669,6 +1009,25 @@ export const SETTER_ABI = [
       },
     ],
     name: "NetworkFeeUpdated",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "oldFee",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "newFee",
+        type: "uint256",
+      },
+    ],
+    name: "NetworkFeeUpdatedSSV",
     type: "event",
   },
   {
@@ -801,9 +1160,9 @@ export const SETTER_ABI = [
     inputs: [
       {
         indexed: false,
-        internalType: "uint64",
+        internalType: "uint256",
         name: "maxFee",
-        type: "uint64",
+        type: "uint256",
       },
     ],
     name: "OperatorMaximumFeeUpdated",
@@ -947,6 +1306,31 @@ export const SETTER_ABI = [
     inputs: [
       {
         indexed: true,
+        internalType: "uint32",
+        name: "oracleId",
+        type: "uint32",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "oldOracle",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "newOracle",
+        type: "address",
+      },
+    ],
+    name: "OracleReplaced",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
         internalType: "address",
         name: "previousOwner",
         type: "address",
@@ -978,6 +1362,170 @@ export const SETTER_ABI = [
       },
     ],
     name: "OwnershipTransferred",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint16",
+        name: "newQuorum",
+        type: "uint16",
+      },
+    ],
+    name: "QuorumUpdated",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "user",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "RewardsClaimed",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "user",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "pending",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "accrued",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "userIndex",
+        type: "uint256",
+      },
+    ],
+    name: "RewardsSettled",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "merkleRoot",
+        type: "bytes32",
+      },
+      {
+        indexed: true,
+        internalType: "uint64",
+        name: "blockNum",
+        type: "uint64",
+      },
+    ],
+    name: "RootCommitted",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "string",
+        name: "version",
+        type: "string",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "blockNumber",
+        type: "uint256",
+      },
+    ],
+    name: "SSVNetworkUpgradeBlock",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "user",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "Staked",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "user",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "unlockTime",
+        type: "uint256",
+      },
+    ],
+    name: "UnstakeRequested",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "user",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "UnstakedWithdrawn",
     type: "event",
   },
   {
@@ -1141,6 +1689,49 @@ export const SETTER_ABI = [
     type: "event",
   },
   {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "merkleRoot",
+        type: "bytes32",
+      },
+      {
+        indexed: true,
+        internalType: "uint64",
+        name: "blockNum",
+        type: "uint64",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "accumulatedWeight",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "quorum",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint32",
+        name: "oracleId",
+        type: "uint32",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "oracle",
+        type: "address",
+      },
+    ],
+    name: "WeightedRootProposed",
+    type: "event",
+  },
+  {
     stateMutability: "nonpayable",
     type: "fallback",
   },
@@ -1187,11 +1778,6 @@ export const SETTER_ABI = [
         type: "bytes[]",
       },
       {
-        internalType: "uint256",
-        name: "amount",
-        type: "uint256",
-      },
-      {
         components: [
           {
             internalType: "uint32",
@@ -1226,7 +1812,7 @@ export const SETTER_ABI = [
     ],
     name: "bulkRegisterValidator",
     outputs: [],
-    stateMutability: "nonpayable",
+    stateMutability: "payable",
     type: "function",
   },
   {
@@ -1293,6 +1879,31 @@ export const SETTER_ABI = [
     type: "function",
   },
   {
+    inputs: [],
+    name: "claimEthRewards",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "merkleRoot",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint64",
+        name: "blockNum",
+        type: "uint64",
+      },
+    ],
+    name: "commitRoot",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
     inputs: [
       {
         internalType: "uint64",
@@ -1321,11 +1932,6 @@ export const SETTER_ABI = [
         internalType: "uint64[]",
         name: "operatorIds",
         type: "uint64[]",
-      },
-      {
-        internalType: "uint256",
-        name: "amount",
-        type: "uint256",
       },
       {
         components: [
@@ -1362,7 +1968,7 @@ export const SETTER_ABI = [
     ],
     name: "deposit",
     outputs: [],
-    stateMutability: "nonpayable",
+    stateMutability: "payable",
     type: "function",
   },
   {
@@ -1437,34 +2043,51 @@ export const SETTER_ABI = [
         type: "address",
       },
       {
-        internalType: "uint64",
-        name: "minimumBlocksBeforeLiquidation_",
-        type: "uint64",
-      },
-      {
-        internalType: "uint256",
-        name: "minimumLiquidationCollateral_",
-        type: "uint256",
-      },
-      {
-        internalType: "uint32",
-        name: "validatorsPerOperatorLimit_",
-        type: "uint32",
-      },
-      {
-        internalType: "uint64",
-        name: "declareOperatorFeePeriod_",
-        type: "uint64",
-      },
-      {
-        internalType: "uint64",
-        name: "executeOperatorFeePeriod_",
-        type: "uint64",
-      },
-      {
-        internalType: "uint64",
-        name: "operatorMaxFeeIncrease_",
-        type: "uint64",
+        components: [
+          {
+            internalType: "uint64",
+            name: "minimumBlocksBeforeLiquidation",
+            type: "uint64",
+          },
+          {
+            internalType: "uint256",
+            name: "minimumLiquidationCollateral",
+            type: "uint256",
+          },
+          {
+            internalType: "uint32",
+            name: "validatorsPerOperatorLimit",
+            type: "uint32",
+          },
+          {
+            internalType: "uint64",
+            name: "declareOperatorFeePeriod",
+            type: "uint64",
+          },
+          {
+            internalType: "uint64",
+            name: "executeOperatorFeePeriod",
+            type: "uint64",
+          },
+          {
+            internalType: "uint64",
+            name: "operatorMaxFeeIncrease",
+            type: "uint64",
+          },
+          {
+            internalType: "uint32[4]",
+            name: "defaultOracleIds",
+            type: "uint32[4]",
+          },
+          {
+            internalType: "uint16",
+            name: "quorumBps",
+            type: "uint16",
+          },
+        ],
+        internalType: "struct ISSVNetwork.NetworkInitParams",
+        name: "params",
+        type: "tuple",
       },
     ],
     name: "initialize",
@@ -1523,6 +2146,124 @@ export const SETTER_ABI = [
     type: "function",
   },
   {
+    inputs: [
+      {
+        internalType: "address",
+        name: "clusterOwner",
+        type: "address",
+      },
+      {
+        internalType: "uint64[]",
+        name: "operatorIds",
+        type: "uint64[]",
+      },
+      {
+        components: [
+          {
+            internalType: "uint32",
+            name: "validatorCount",
+            type: "uint32",
+          },
+          {
+            internalType: "uint64",
+            name: "networkFeeIndex",
+            type: "uint64",
+          },
+          {
+            internalType: "uint64",
+            name: "index",
+            type: "uint64",
+          },
+          {
+            internalType: "bool",
+            name: "active",
+            type: "bool",
+          },
+          {
+            internalType: "uint256",
+            name: "balance",
+            type: "uint256",
+          },
+        ],
+        internalType: "struct ISSVNetworkCore.Cluster",
+        name: "cluster",
+        type: "tuple",
+      },
+    ],
+    name: "liquidateSSV",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint64[]",
+        name: "operatorIds",
+        type: "uint64[]",
+      },
+      {
+        components: [
+          {
+            internalType: "uint32",
+            name: "validatorCount",
+            type: "uint32",
+          },
+          {
+            internalType: "uint64",
+            name: "networkFeeIndex",
+            type: "uint64",
+          },
+          {
+            internalType: "uint64",
+            name: "index",
+            type: "uint64",
+          },
+          {
+            internalType: "bool",
+            name: "active",
+            type: "bool",
+          },
+          {
+            internalType: "uint256",
+            name: "balance",
+            type: "uint256",
+          },
+        ],
+        internalType: "struct ISSVNetworkCore.Cluster",
+        name: "cluster",
+        type: "tuple",
+      },
+    ],
+    name: "migrateClusterToETH",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "from",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "onCSSVTransfer",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
     inputs: [],
     name: "owner",
     outputs: [
@@ -1569,11 +2310,6 @@ export const SETTER_ABI = [
         type: "uint64[]",
       },
       {
-        internalType: "uint256",
-        name: "amount",
-        type: "uint256",
-      },
-      {
         components: [
           {
             internalType: "uint32",
@@ -1608,7 +2344,7 @@ export const SETTER_ABI = [
     ],
     name: "reactivate",
     outputs: [],
-    stateMutability: "nonpayable",
+    stateMutability: "payable",
     type: "function",
   },
   {
@@ -1676,11 +2412,6 @@ export const SETTER_ABI = [
         type: "bytes",
       },
       {
-        internalType: "uint256",
-        name: "amount",
-        type: "uint256",
-      },
-      {
         components: [
           {
             internalType: "uint32",
@@ -1715,7 +2446,7 @@ export const SETTER_ABI = [
     ],
     name: "registerValidator",
     outputs: [],
-    stateMutability: "nonpayable",
+    stateMutability: "payable",
     type: "function",
   },
   {
@@ -1822,6 +2553,60 @@ export const SETTER_ABI = [
   {
     inputs: [
       {
+        internalType: "uint32",
+        name: "oracleId",
+        type: "uint32",
+      },
+      {
+        internalType: "address",
+        name: "newOracle",
+        type: "address",
+      },
+    ],
+    name: "replaceOracle",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "requestUnstake",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "token",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "rescueERC20",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
         internalType: "address",
         name: "recipientAddress",
         type: "address",
@@ -1897,12 +2682,123 @@ export const SETTER_ABI = [
   {
     inputs: [
       {
+        internalType: "uint16",
+        name: "quorum",
+        type: "uint16",
+      },
+    ],
+    name: "setQuorumBps",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint64",
+        name: "duration",
+        type: "uint64",
+      },
+    ],
+    name: "setUnstakeCooldownDuration",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "stake",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "syncFees",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
         internalType: "address",
         name: "newOwner",
         type: "address",
       },
     ],
     name: "transferOwnership",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint64",
+        name: "blockNum",
+        type: "uint64",
+      },
+      {
+        internalType: "address",
+        name: "clusterOwner",
+        type: "address",
+      },
+      {
+        internalType: "uint64[]",
+        name: "operatorIds",
+        type: "uint64[]",
+      },
+      {
+        components: [
+          {
+            internalType: "uint32",
+            name: "validatorCount",
+            type: "uint32",
+          },
+          {
+            internalType: "uint64",
+            name: "networkFeeIndex",
+            type: "uint64",
+          },
+          {
+            internalType: "uint64",
+            name: "index",
+            type: "uint64",
+          },
+          {
+            internalType: "bool",
+            name: "active",
+            type: "bool",
+          },
+          {
+            internalType: "uint256",
+            name: "balance",
+            type: "uint256",
+          },
+        ],
+        internalType: "struct ISSVNetworkCore.Cluster",
+        name: "cluster",
+        type: "tuple",
+      },
+      {
+        internalType: "uint32",
+        name: "effectiveBalance",
+        type: "uint32",
+      },
+      {
+        internalType: "bytes32[]",
+        name: "merkleProof",
+        type: "bytes32[]",
+      },
+    ],
+    name: "updateClusterBalance",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",
@@ -1950,8 +2846,21 @@ export const SETTER_ABI = [
     inputs: [
       {
         internalType: "uint64",
-        name: "maxFee",
+        name: "blocks",
         type: "uint64",
+      },
+    ],
+    name: "updateLiquidationThresholdPeriodSSV",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "maxFee",
+        type: "uint256",
       },
     ],
     name: "updateMaximumOperatorFee",
@@ -1968,6 +2877,32 @@ export const SETTER_ABI = [
       },
     ],
     name: "updateMinimumLiquidationCollateral",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "updateMinimumLiquidationCollateralSSV",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "minFee",
+        type: "uint256",
+      },
+    ],
+    name: "updateMinimumOperatorEthFee",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",
@@ -1999,6 +2934,19 @@ export const SETTER_ABI = [
       },
     ],
     name: "updateNetworkFee",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "fee",
+        type: "uint256",
+      },
+    ],
+    name: "updateNetworkFeeSSV",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",
@@ -2113,12 +3061,38 @@ export const SETTER_ABI = [
   {
     inputs: [
       {
+        internalType: "uint64",
+        name: "operatorId",
+        type: "uint64",
+      },
+    ],
+    name: "withdrawAllOperatorEarningsSSV",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint64",
+        name: "operatorId",
+        type: "uint64",
+      },
+    ],
+    name: "withdrawAllVersionOperatorEarnings",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
         internalType: "uint256",
         name: "amount",
         type: "uint256",
       },
     ],
-    name: "withdrawNetworkEarnings",
+    name: "withdrawNetworkSSVEarnings",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",
@@ -2137,6 +3111,31 @@ export const SETTER_ABI = [
       },
     ],
     name: "withdrawOperatorEarnings",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint64",
+        name: "operatorId",
+        type: "uint64",
+      },
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "withdrawOperatorEarningsSSV",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "withdrawUnlocked",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",

--- a/src/lib/utils/account-events.ts
+++ b/src/lib/utils/account-events.ts
@@ -4,7 +4,9 @@ import { type SETTER_ABI } from "@/lib/abi/setter"
 
 export type AccountEventName = ExtractAbiEventNames<typeof SETTER_ABI>
 
-export const ACCOUNT_EVENTS_EMOJI_MAP: Record<AccountEventName, string> = {
+export const ACCOUNT_EVENTS_EMOJI_MAP: Partial<
+  Record<AccountEventName, string>
+> = {
   // Admin & System Events
   AdminChanged: "🔧",
   Initialized: "🚀",
@@ -17,10 +19,12 @@ export const ACCOUNT_EVENTS_EMOJI_MAP: Record<AccountEventName, string> = {
   OwnershipTransferred: "👑",
 
   // Cluster Events
+  ClusterBalanceUpdated: "📊",
   ClusterDeposited: "💰",
   ClusterLiquidated: "💥",
   ClusterReactivated: "🔄",
   ClusterWithdrawn: "💸",
+  ClusterMigratedToETH: "💫",
 
   // Validator Events
   ValidatorAdded: "➕",
@@ -54,10 +58,33 @@ export const ACCOUNT_EVENTS_EMOJI_MAP: Record<AccountEventName, string> = {
   FeeRecipientAddressUpdated: "📬",
 
   // Period & Threshold Updates
+  CooldownDurationUpdated: "⏳",
   DeclareOperatorFeePeriodUpdated: "⏰",
   ExecuteOperatorFeePeriodUpdated: "⏱️",
+  LiquidationThresholdPeriodSSVUpdated: "⚠️",
   LiquidationThresholdPeriodUpdated: "⚠️",
+  MinimumLiquidationCollateralSSVUpdated: "💎",
   MinimumLiquidationCollateralUpdated: "💎",
+  MinimumOperatorEthFeeUpdated: "💳",
+
+  // Rescue & Sync Events
+  ERC20Rescued: "🆘",
+  FeesSynced: "🔄",
+
+  // Network Events
+  NetworkFeeUpdatedSSV: "💳",
+  OracleReplaced: "🔮",
+  QuorumUpdated: "📊",
+  SSVNetworkUpgradeBlock: "⬆️",
+
+  // Rewards & Staking Events
+  RewardsClaimed: "🎁",
+  RewardsSettled: "💵",
+  RootCommitted: "📝",
+  Staked: "🔒",
+  UnstakeRequested: "📤",
+  UnstakedWithdrawn: "💸",
+  WeightedRootProposed: "📋",
 }
 
 export const getAccountEventIcon = (event: AccountEventName) => {


### PR DESCRIPTION
## F-explorer-014 — Explorer ETH Fee Precision Too Coarse (2dp) (✅ Done)

- Severity: P1
- Repo: `ssv-explorer`
- Effort: S
- Owner: FE3 (Sumbat)

Problem:
Explorer fee filtering/display is too coarse at 2 decimals for ETH-denominated values.

Scope:

- Raise ETH precision to 4 decimals (`0.0001 ETH`) in input/display.
- Preserve precision in URL/query params.
- Ensure values do not collapse back to 2dp in formatter paths.

Acceptance Criteria:

- Filtering ranges like `0.1234` to `0.1238` remain distinct.
- Query params carry 4dp values.
- No regression in non-ETH fee views.


## F-explorer-007 — No Migration Event or Status Display (✅ Done)

- Severity: P1
- Repo: `ssv-explorer`
- Effort: S
- Owner: FE3 (Sumbat)

Problem:
Migration-to-ETH event/status is not visible enough in explorer history/status surfaces.

Scope:

- Render `ClusterMigratedToETH` in history timelines.
- Add migration status indicator where relevant.
- Keep non-migrated entities clean (no false positives).

Acceptance Criteria:

- Migrated clusters show migration event/status.
- Non-migrated clusters show no false migration state.
- No regressions to existing history rendering.