### PR TITLE
refactor: Operator Yearly Fee Dual Display Missing SSV Ticker

### DIFF
--- a/src/components/operators/operator-meta-data.tsx
+++ b/src/components/operators/operator-meta-data.tsx
@@ -5,12 +5,10 @@ import { Collapse } from "react-collapse"
 import { FaGlobe, FaLinkedin } from "react-icons/fa"
 import { FaXTwitter } from "react-icons/fa6"
 import { LuChevronDown } from "react-icons/lu"
-import { formatUnits } from "viem"
 
 import { type Operator } from "@/types/api"
-import { globals } from "@/config/globals"
 import { cn } from "@/lib/utils"
-import { ethFormatter, formatSSV } from "@/lib/utils/number"
+import { formatETH, formatSSV } from "@/lib/utils/number"
 import { getYearlyFee } from "@/lib/utils/operator"
 import { Button } from "@/components/ui/button"
 import { CopyBtn } from "@/components/ui/copy-btn"
@@ -51,11 +49,7 @@ export const OperatorMetaData: OperatorMetaDataFC = ({
                 <div className="flex items-center gap-2">
                   {BigInt(operator.eth_fee || 0) > 0 ? (
                     <Text variant="body-3-medium">
-                      {(() => {
-                        const yearlyEthFee =
-                          BigInt(operator.eth_fee) * globals.BLOCKS_PER_YEAR
-                        return `${ethFormatter.format(+formatUnits(yearlyEthFee, 18))} ETH`
-                      })()}
+                      {formatETH(getYearlyFee(BigInt(operator.eth_fee)))} ETH
                     </Text>
                   ) : (
                     <Text variant="body-3-medium" className="text-gray-400">
@@ -64,7 +58,7 @@ export const OperatorMetaData: OperatorMetaDataFC = ({
                   )}
                   {BigInt(operator.fee || 0) > 0 ? (
                     <Text variant="body-3-medium">
-                      {formatSSV(getYearlyFee(BigInt(operator.fee)))}
+                      {formatSSV(getYearlyFee(BigInt(operator.fee)))} SSV
                     </Text>
                   ) : (
                     <Text variant="body-3-medium" className="text-gray-400">


### PR DESCRIPTION
### F-explorer-020 — Operator Yearly Fee Dual Display Missing SSV Ticker (✅ Done)

- **Problem:** Mixed fee row shows ETH value + second value without explicit `SSV` ticker.
- **Fix:** Ensure denomination label/icon is explicit for both values in mixed ETH+SSV rendering.
- **Validation:** Operator yearly fee rows display `ETH` and `SSV` consistently in all mixed/edge cases.
- **How to QA:** Check operator pages with ETH-only, SSV-only, and dual-denomination data.