### PR TITLE
fix: format ETH staked number with thousands separator

### DIFF
--- a/src/app/[network]/overview/page.tsx
+++ b/src/app/[network]/overview/page.tsx
@@ -148,7 +148,7 @@ export default async function Page(props: IndexPageProps) {
             className="flex-1"
             title={`${nativeCurrency.symbol} Staked`}
             tooltip={`Total amount of ${nativeCurrency.symbol} staked across all validators on the network`}
-            content={`${totalStakedEth} ${nativeCurrency.symbol}`}
+            content={`${numberFormatter.format(Number(totalStakedEth))} ${nativeCurrency.symbol}`}
           />
         </Card>
       </div>


### PR DESCRIPTION
- Apply numberFormatter to totalStakedEth display
- Changes format from "1595875 ETH" to "1,595,875 ETH"
- Improves readability of large numbers on overview page

🤖 Generated with [Claude Code](https://claude.com/claude-code)