### PR TITLE
fix(config): use NEXT_PUBLIC_ENV for SSV explorer links and set prod SITE_URL

### DIFF
--- a/.env.prod
+++ b/.env.prod
@@ -1,3 +1,5 @@
+NEXT_PUBLIC_ENV=production
 NEXT_PUBLIC_SSV_NETWORKS='[{"networkId":1,"apiVersion":"v4","apiNetwork":"mainnet","api":"https://api.ssv.network/api","explorerUrl":"https://etherscan.io","insufficientBalanceUrl":"https://faucet.ssv.network/","tokenAddress":"0x9D65fF81a3c488d585bBfb0Bfe3c7707c7917f54","setterContractAddress":"0xDD9BC35aE942eF0cFa76930954a156B3fF30a4E1","getterContractAddress":"0xafE830B6Ee262ba11cce5F32fDCd760FFE6a66e4"},{"networkId":560048,"apiVersion":"v4","apiNetwork":"hoodi","api":"https://api.hoodi.ssv.network/api","explorerUrl":"https://hoodi.etherscan.io","insufficientBalanceUrl":"https://faucet.ssv.network/","tokenAddress":"0x9F5d4Ec84fC4785788aB44F9de973cF34F7A038e","setterContractAddress":"0x58410Bef803ECd7E63B23664C586A6DB72DAf59c","getterContractAddress":"0x5AdDb3f1529C5ec70D77400499eE4bbF328368fe"}]'
 NEXT_PUBLIC_COINGECKO_API_URL=https://api.coingecko.com/api/
 NEXT_PUBLIC_COINGECKO_API_KEY=<API-Key>
+SITE_URL=https://preview.explorer.ssv.network

--- a/.env.stage
+++ b/.env.stage
@@ -1,3 +1,5 @@
+NEXT_PUBLIC_ENV=stage
 NEXT_PUBLIC_SSV_NETWORKS='[{"networkId":560048,"apiVersion":"v4","apiNetwork":"hoodi","api":"https://api.stage.ops.ssvlabsinternal.com/api","explorerUrl":"https://explorer.stage.ssv.network","insufficientBalanceUrl":"https://faucet.ssv.network","googleTagSecret":"GTM-K3GR7M5","tokenAddress":"0x746c33ccc28b1363c35c09badaf41b2ffa7e6d56","setterContractAddress":"0xc07B3E9671f884FDa67E1e7D43d952E0e1369fd8","getterContractAddress":"0x3234e84b7d1eE1AF8b586E26814d4e268336D142"}]'
 NEXT_PUBLIC_COINGECKO_API_URL=https://api.coingecko.com/api/
 NEXT_PUBLIC_COINGECKO_API_KEY=<API-Key>
+SITE_URL=https://explorer.stage.ssv.network

--- a/src/env.js
+++ b/src/env.js
@@ -28,6 +28,9 @@ export const env = createEnv({
    */
   client: {
     // NEXT_PUBLIC_CLIENTVAR: z.string(),
+    NEXT_PUBLIC_ENV: z
+      .enum(["development", "stage", "production"])
+      .default("development"),
     NEXT_PUBLIC_SSV_NETWORKS: z
       .string()
       .default(
@@ -42,6 +45,7 @@ export const env = createEnv({
   runtimeEnv: {
     NODE_ENV: process.env.NODE_ENV,
     SSV_NETWORKS: process.env.SSV_NETWORKS,
+    NEXT_PUBLIC_ENV: process.env.NEXT_PUBLIC_ENV,
     NEXT_PUBLIC_SSV_NETWORKS: process.env.NEXT_PUBLIC_SSV_NETWORKS,
     SITE_URL: process.env.SITE_URL,
   },

--- a/src/hooks/use-links.ts
+++ b/src/hooks/use-links.ts
@@ -1,11 +1,12 @@
 "use client"
 
 import { useMemo } from "react"
+import { env } from "@/env"
 
 import { useNetworkQuery } from "@/hooks/search/use-network-query"
 
 export const useLinks = () => {
-  const isProduction = false // TODO: fix this
+  const isProduction = env.NEXT_PUBLIC_ENV === "production"
   const { chain } = useNetworkQuery()
 
   return useMemo(() => {


### PR DESCRIPTION

This PR fixes incorrect SSV internal link routing caused by a hardcoded production flag in `use-links`.

## Changes
- Replaced hardcoded `isProduction = false` with `env.NEXT_PUBLIC_ENV === "production"` in `src/hooks/use-links.ts`.
- Added `NEXT_PUBLIC_ENV` to client env schema/runtime mapping in `src/env.js`.
- Updated env files:
  - `.env.prod`: added `NEXT_PUBLIC_ENV=production`, `SITE_URL=https://explorer.ssv.network`
  - `.env.stage`: added `NEXT_PUBLIC_ENV=stage`, `SITE_URL=https://explorer.stage.ssv.network`

## Verification
- `pnpm eslint src/hooks/use-links.ts src/env.js`
- `pnpm typecheck`

## Notes
- Etherscan links remain chain/testnet-dependent and are unaffected by this change.