### PR TITLE
F-explorer-024: enforce TypeScript errors in Next.js build

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts"
+import "./.next/types/routes.d.ts"
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -6,8 +6,6 @@ await import("./src/env.js")
 
 /** @type {import("next").NextConfig} */
 const nextConfig = {
-  typescript: { ignoreBuildErrors: true },
-
   // Enable compression for better performance
   compress: true,
 


### PR DESCRIPTION
## Summary
This PR addresses `F-explorer-024` by removing the Next.js config override that allowed TypeScript errors to pass during build.

## Changes
- Removed `typescript: { ignoreBuildErrors: true }` from `next.config.js`.
- Regenerated Next type artifacts (`next-env.d.ts` now references `./.next/types/routes.d.ts`).

## Verification
- `pnpm typegen`
- `pnpm exec tsc --noEmit`
- `pnpm exec next build`

All checks passed.