### PR TITLE
F-explorer-025 - feat/app-router-route-error-boundaries

### DIFF
--- a/src/app/[network]/account/[address]/clusters/error.tsx
+++ b/src/app/[network]/account/[address]/clusters/error.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+import RouteError, { type RouteErrorProps } from "@/app/_components/route-error"
+
+export default function AccountClustersRouteError(props: RouteErrorProps) {
+  return (
+    <RouteError
+      {...props}
+      title="Couldn't load account clusters"
+      fallbackMessage="We couldn't load clusters for this account."
+    />
+  )
+}

--- a/src/app/[network]/account/[address]/error.tsx
+++ b/src/app/[network]/account/[address]/error.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+import RouteError, { type RouteErrorProps } from "@/app/_components/route-error"
+
+export default function AccountDetailsRouteError(props: RouteErrorProps) {
+  return (
+    <RouteError
+      {...props}
+      title="Couldn't load account details"
+      fallbackMessage="We couldn't load this account right now."
+    />
+  )
+}

--- a/src/app/[network]/account/[address]/history/error.tsx
+++ b/src/app/[network]/account/[address]/history/error.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+import RouteError, { type RouteErrorProps } from "@/app/_components/route-error"
+
+export default function AccountHistoryRouteError(props: RouteErrorProps) {
+  return (
+    <RouteError
+      {...props}
+      title="Couldn't load account history"
+      fallbackMessage="We couldn't load history for this account."
+    />
+  )
+}

--- a/src/app/[network]/account/[address]/operators/error.tsx
+++ b/src/app/[network]/account/[address]/operators/error.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+import RouteError, { type RouteErrorProps } from "@/app/_components/route-error"
+
+export default function AccountOperatorsRouteError(props: RouteErrorProps) {
+  return (
+    <RouteError
+      {...props}
+      title="Couldn't load account operators"
+      fallbackMessage="We couldn't load operators for this account."
+    />
+  )
+}

--- a/src/app/[network]/accounts/error.tsx
+++ b/src/app/[network]/accounts/error.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+import RouteError, { type RouteErrorProps } from "@/app/_components/route-error"
+
+export default function AccountsRouteError(props: RouteErrorProps) {
+  return (
+    <RouteError
+      {...props}
+      title="Couldn't load accounts"
+      fallbackMessage="We couldn't load accounts for this network."
+    />
+  )
+}

--- a/src/app/[network]/cluster/[id]/error.tsx
+++ b/src/app/[network]/cluster/[id]/error.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+import RouteError, { type RouteErrorProps } from "@/app/_components/route-error"
+
+export default function ClusterDetailsRouteError(props: RouteErrorProps) {
+  return (
+    <RouteError
+      {...props}
+      title="Couldn't load cluster details"
+      fallbackMessage="We couldn't load this cluster right now."
+    />
+  )
+}

--- a/src/app/[network]/clusters/error.tsx
+++ b/src/app/[network]/clusters/error.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+import RouteError, { type RouteErrorProps } from "@/app/_components/route-error"
+
+export default function ClustersRouteError(props: RouteErrorProps) {
+  return (
+    <RouteError
+      {...props}
+      title="Couldn't load clusters"
+      fallbackMessage="We couldn't load clusters for this network."
+    />
+  )
+}

--- a/src/app/[network]/error.tsx
+++ b/src/app/[network]/error.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+import RouteError, { type RouteErrorProps } from "@/app/_components/route-error"
+
+export default function NetworkRouteError(props: RouteErrorProps) {
+  return (
+    <RouteError
+      {...props}
+      title="Couldn't load network page"
+      fallbackMessage="Please try reloading this network route."
+    />
+  )
+}

--- a/src/app/[network]/operator/[id]/error.tsx
+++ b/src/app/[network]/operator/[id]/error.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+import RouteError, { type RouteErrorProps } from "@/app/_components/route-error"
+
+export default function OperatorDetailsRouteError(props: RouteErrorProps) {
+  return (
+    <RouteError
+      {...props}
+      title="Couldn't load operator details"
+      fallbackMessage="We couldn't load this operator right now."
+    />
+  )
+}

--- a/src/app/[network]/operator/[id]/history/error.tsx
+++ b/src/app/[network]/operator/[id]/history/error.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+import RouteError, { type RouteErrorProps } from "@/app/_components/route-error"
+
+export default function OperatorHistoryRouteError(props: RouteErrorProps) {
+  return (
+    <RouteError
+      {...props}
+      title="Couldn't load operator history"
+      fallbackMessage="We couldn't load this operator's history right now."
+    />
+  )
+}

--- a/src/app/[network]/operators/error.tsx
+++ b/src/app/[network]/operators/error.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+import RouteError, { type RouteErrorProps } from "@/app/_components/route-error"
+
+export default function OperatorsRouteError(props: RouteErrorProps) {
+  return (
+    <RouteError
+      {...props}
+      title="Couldn't load operators"
+      fallbackMessage="We couldn't load operators for this network."
+    />
+  )
+}

--- a/src/app/[network]/overview/error.tsx
+++ b/src/app/[network]/overview/error.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+import RouteError, { type RouteErrorProps } from "@/app/_components/route-error"
+
+export default function OverviewRouteError(props: RouteErrorProps) {
+  return (
+    <RouteError
+      {...props}
+      title="Couldn't load overview"
+      fallbackMessage="We couldn't load network overview data."
+    />
+  )
+}

--- a/src/app/[network]/validator/[publicKey]/error.tsx
+++ b/src/app/[network]/validator/[publicKey]/error.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+import RouteError, { type RouteErrorProps } from "@/app/_components/route-error"
+
+export default function ValidatorDetailsRouteError(props: RouteErrorProps) {
+  return (
+    <RouteError
+      {...props}
+      title="Couldn't load validator details"
+      fallbackMessage="We couldn't load this validator right now."
+    />
+  )
+}

--- a/src/app/[network]/validators/error.tsx
+++ b/src/app/[network]/validators/error.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+import RouteError, { type RouteErrorProps } from "@/app/_components/route-error"
+
+export default function ValidatorsRouteError(props: RouteErrorProps) {
+  return (
+    <RouteError
+      {...props}
+      title="Couldn't load validators"
+      fallbackMessage="We couldn't load validators for this network."
+    />
+  )
+}

--- a/src/app/_components/route-error.tsx
+++ b/src/app/_components/route-error.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { useEffect } from "react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { ErrorCard } from "@/components/ui/error-card"
+
+export type RouteErrorProps = {
+  error: Error & { digest?: string }
+  reset: () => void
+  className?: string
+  title?: string
+  fallbackMessage?: string
+}
+
+export default function RouteError({
+  error,
+  reset,
+  className,
+  title = "Something went wrong",
+  fallbackMessage = "An unexpected error occurred while loading this page.",
+}: RouteErrorProps) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <div
+      className={cn(
+        "flex flex-1 flex-col items-center justify-center gap-4 p-6",
+        className
+      )}
+    >
+      <ErrorCard
+        className="w-full max-w-2xl bg-transparent"
+        title={title}
+        errorMessage={error.message || fallbackMessage}
+      />
+      <Button onClick={reset} variant="secondary">
+        Try again
+      </Button>
+    </div>
+  )
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,3 @@
+"use client"
+
+export { default } from "@/app/_components/route-error"


### PR DESCRIPTION
## Summary
- add shared App Router error UI component in `src/app/_components/route-error.tsx`
- add root fallback `src/app/error.tsx`
- add per-route `error.tsx` boundaries for all data-loading routes under `src/app/[network]/**`
- add `[network]/error.tsx` fallback boundary
- remove temporary simulated throw from `src/app/[network]/operators/page.tsx`
- keep route-specific wrappers with typed `error`/`reset` props and route-specific copy

## Why
- prevent unhandled route errors from collapsing into a blank page
- provide user-facing feedback and retry (`reset`) at the nearest route segment
- keep errors isolated to affected route instead of escalating to app-level fallback

## Validation
- `pnpm -s tsc --noEmit` passes
- verified `error.tsx` coverage exists for each data-loading route segment