### PR TITLE
chore(ci) - Update actions base image to node:24

### DIFF
--- a/.github/workflows/lint_build.yml
+++ b/.github/workflows/lint_build.yml
@@ -33,19 +33,19 @@ jobs:
         ]
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@v6.0.2 # v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
+      - uses: actions/setup-node@v6.3.0 # v3
         with:
           node-version: 20.12.2
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v5.0.0
         with:
           version: 9.0.6
 
-      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      - uses: actions/cache@v5.0.4 # v3
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/monday_automation.yml
+++ b/.github/workflows/monday_automation.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event.pull_request.merged == true || github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 # Need to checkout the code to access the script
+      - uses: actions/checkout@v6.0.2 # v4 # Need to checkout the code to access the script
 
       - name: Setup Node.js
         uses: actions/setup-node@v6.3.0 # v3

--- a/.github/workflows/monday_automation.yml
+++ b/.github/workflows/monday_automation.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 # Need to checkout the code to access the script
 
       - name: Setup Node.js
-        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
+        uses: actions/setup-node@v6.3.0 # v3
         with:
           node-version: 20.12.2 # Use the same version as in build_deploy.yml
 


### PR DESCRIPTION
## Summary
GitHub is enforcing Node.js 24 for GitHub Actions runtime and will block workflows that rely on older Node runtimes.

This PR updates CI workflows to align with the requirement.

## Changes
- Update reusable action references (`uses:`) to latest released versions.
- Update workflow Node container images (`node:<version>`) to `node:24` where they were below 24.