### PR TITLE
feat: adjust Accounts ETH Managed filter inputs and max range

### DIFF
--- a/src/app/_components/accounts/account-table-filters.tsx
+++ b/src/app/_components/accounts/account-table-filters.tsx
@@ -45,6 +45,7 @@ export const AccountTableFilters = () => {
           name="ETH Managed"
           searchQueryKey="totalOperatorEthManaged"
           parser={accountsSearchFilters.totalOperatorEthManaged}
+          showSlider={false}
           suffix=""
           step={1}
           decimals={0}

--- a/src/app/_components/shared/filters/range-filter.tsx
+++ b/src/app/_components/shared/filters/range-filter.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { isEqual } from "lodash-es"
-import { useQueryState, type ParserBuilder } from "nuqs"
+import { useQueryState, type SingleParserBuilder } from "nuqs"
 
 import { Text } from "@/components/ui/text"
 import { FilterButton } from "@/components/filter/filter-button"
@@ -10,8 +10,11 @@ import { Range, type RangeProps } from "@/components/filter/range-filter"
 type Props<TSearchKey extends string = string> = {
   name: string
   searchQueryKey: TSearchKey
-  parser: ParserBuilder<[number, number]> & { defaultValue: [number, number] }
+  parser: SingleParserBuilder<[number, number]> & {
+    defaultValue: [number, number]
+  }
   inputs?: RangeProps["inputs"]
+  showSlider?: RangeProps["showSlider"]
   suffix?: string
   step?: number
   decimals?: number
@@ -21,6 +24,7 @@ export const RangeFilter = <TSearchKey extends string = string>({
   searchQueryKey,
   parser,
   inputs,
+  showSlider,
   suffix,
   step = 0.1,
   decimals = 1,
@@ -57,6 +61,7 @@ export const RangeFilter = <TSearchKey extends string = string>({
         defaultRange={defaultRange}
         apply={apply}
         remove={remove}
+        showSlider={showSlider}
         step={step}
         decimals={decimals}
         inputs={

--- a/src/components/filter/range-filter.tsx
+++ b/src/components/filter/range-filter.tsx
@@ -19,6 +19,7 @@ export type RangeProps = {
   name: string
   defaultRange: [number, number]
   searchRange: [number, number] | null
+  showSlider?: boolean
   step?: number
   min?: number
   max?: number
@@ -37,6 +38,7 @@ export const Range: FC<ComponentPropsWithoutRef<"form"> & RangeProps> = ({
   inputs,
   min,
   max,
+  showSlider = true,
   step = 0.01,
   decimals = 0,
   searchRange,
@@ -137,13 +139,15 @@ export const Range: FC<ComponentPropsWithoutRef<"form"> & RangeProps> = ({
               onChange={(newEnd) => setRange([range[0], newEnd])}
             />
           </div>
-          <RangeSlider
-            className="py-1"
-            value={form.watch("range")}
-            max={defaultRange[1]}
-            step={step}
-            onValueChange={(values) => setRange(values as [number, number])}
-          />
+          {showSlider ? (
+            <RangeSlider
+              className="py-1"
+              value={form.watch("range")}
+              max={defaultRange[1]}
+              step={step}
+              onValueChange={(values) => setRange(values as [number, number])}
+            />
+          ) : null}
         </div>
         <div className="flex justify-end gap-2 border-t border-gray-300 p-4">
           <Button

--- a/src/lib/search-parsers/accounts-search-parsers.ts
+++ b/src/lib/search-parsers/accounts-search-parsers.ts
@@ -28,7 +28,7 @@ export const accountsSearchFilters = {
   operators: numberRangeParser.withDefault([0, 5000]),
   clusters: numberRangeParser.withDefault([0, 5000]),
   validators: numberRangeParser.withDefault([0, 200000]),
-  totalOperatorEthManaged: numberRangeParser.withDefault([0, 500 * 2048]),
+  totalOperatorEthManaged: numberRangeParser.withDefault([0, 2048 * 3000]),
   effectiveBalance: effectiveBalanceParser,
 }
 


### PR DESCRIPTION
## Summary
- remove the slider from the `ETH Managed` filter on the Accounts page
- keep only the min and max numeric inputs for that filter
- increase the `ETH Managed` filter max range to `6,144,000 ETH` (`2048 * 3000`)

## Details
- added a `showSlider` option to the shared range filter so the slider can be disabled selectively
- disabled the slider only for the Accounts page `ETH Managed` filter
- updated the Accounts search parser default range for `totalOperatorEthManaged` from `500 * 2048` to `2048 * 3000`
