### PR TITLE
fix/account-effective-balance-range-serialization

### DIFF
--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -16,22 +16,32 @@ import {
 import { stringifyBigints } from "@/lib/utils/bigint"
 import { unstable_cache } from "@/lib/utils/unstable-cache"
 
+const serializeEffectiveBalance = ([min, max]: [number, number]) =>
+  [
+    formatGwei(parseEther(min.toString())),
+    formatGwei(parseEther(max.toString())),
+  ].join(",")
+
 export const searchAccounts = async (
   params: Partial<AccountsSearchSchema> & { network: ChainName }
 ): Promise<PaginatedAccountsResponse> =>
   await unstable_cache(
     async () => {
-      const augmentedParams = {
-        ...params,
-        effectiveBalance: params.effectiveBalance
-          ? (params.effectiveBalance.map(
-              (value) => +formatGwei(parseEther(value.toString()))
-            ) as [number, number])
-          : params.effectiveBalance,
+      const searchParams = new URLSearchParams(
+        accountSearchParamsSerializer(params)
+      )
+      if (params.effectiveBalance) {
+        searchParams.set(
+          "effectiveBalance",
+          serializeEffectiveBalance(params.effectiveBalance)
+        )
       }
-
-      const searchParams = accountSearchParamsSerializer(augmentedParams)
-      const url = endpoint(params.network, "accounts", searchParams)
+      const serializedSearchParams = searchParams.toString()
+      const url = endpoint(
+        params.network,
+        "accounts",
+        serializedSearchParams ? `?${serializedSearchParams}` : ""
+      )
       return api.get<PaginatedAccountsResponse>(url)
     },
     [JSON.stringify(stringifyBigints(params))],

--- a/src/components/filter/open-range-filter.tsx
+++ b/src/components/filter/open-range-filter.tsx
@@ -103,6 +103,8 @@ export const OpenRange: FC<
           <div className="flex items-center justify-between">
             <NumberInput
               id="first-input"
+              min={min ?? defaultRange[0]}
+              max={max ?? defaultRange[1]}
               decimals={decimals}
               {...inputs?.start}
               step={step}
@@ -118,6 +120,8 @@ export const OpenRange: FC<
               }}
             />
             <NumberInput
+              min={min ?? defaultRange[0]}
+              max={max ?? defaultRange[1]}
               decimals={decimals}
               {...inputs?.end}
               step={step}

--- a/src/lib/search-parsers/shared/parsers.ts
+++ b/src/lib/search-parsers/shared/parsers.ts
@@ -43,7 +43,7 @@ export const effectiveBalanceParser = parseAsTuple(
     postParse: sortNumbers,
   }
 )
-  .withDefault([0, 25000])
+  .withDefault([0, 2048 * 3000])
   .withOptions(defaultSearchOptions)
 
 const bigintTuple = z.tuple([
@@ -80,8 +80,8 @@ export const getEffectiveBalanceParser = ({
       }
     },
     serialize: ([_min, _max]) => {
-      const min = serializeToGwei ? Number(parseGwei(`${_min}`)) : _min
-      const max = serializeToGwei ? Number(parseGwei(`${_max}`)) : _max
+      const min = serializeToGwei ? parseGwei(`${_min}`).toString() : `${_min}`
+      const max = serializeToGwei ? parseGwei(`${_max}`).toString() : `${_max}`
       if (min && max) return `${min},${max}`
       if (min) return `${min},`
       if (max) return `,${max}`


### PR DESCRIPTION
## Summary
- fix `effectiveBalance` query serialization for accounts to avoid scientific notation in the URL
- keep effective-balance conversions as decimal strings instead of coercing through JavaScript `number`
- set account effective-balance default range to `[0, 2048 * 3000]`
- make effective-balance input bounds derive from the parser default range

## Problem
Account effective-balance filters could serialize large values like `9000000000000` into scientific notation, producing invalid query params such as `effectiveBalance=0,9e%2B21`.

## Fix
- override account effective-balance serialization to emit exact decimal string values
- update shared effective-balance serializer to avoid `Number(...)` during gwei serialization
- use the account parser default range as the source of truth for input min/max

## Verification
- confirmed the old path produced `9e+21`
- confirmed the new path produces `9000000000000000000000`
- ran `pnpm typecheck`