### PR TITLE
F-explorer-028 - fix(accounts): make EB filter default state unbounded

### DIFF
--- a/src/app/_components/shared/filters/effective-balance-filter.tsx
+++ b/src/app/_components/shared/filters/effective-balance-filter.tsx
@@ -12,7 +12,7 @@ type Props<TSearchKey extends string = string> = {
   name: string
   searchQueryKey: TSearchKey
   parser: SingleParserBuilder<[number, number]> & {
-    defaultValue: [number, number]
+    defaultValue?: [number, number]
   }
 }
 export function EffectiveBalanceFilter<TSearchKey extends string = string>({
@@ -23,7 +23,7 @@ export function EffectiveBalanceFilter<TSearchKey extends string = string>({
   const popup = useDisclosure()
 
   const [searchRange, setSearchRange] = useQueryState(searchQueryKey, parser)
-  const defaultRange = parser.defaultValue
+  const defaultRange = parser.defaultValue ?? [0, 0]
 
   const isActive = !isEqual(searchRange, defaultRange) && Boolean(searchRange)
 
@@ -55,6 +55,7 @@ export function EffectiveBalanceFilter<TSearchKey extends string = string>({
         name={name}
         searchRange={searchRange}
         defaultRange={defaultRange}
+        min={0}
         apply={apply}
         remove={remove}
         step={1}

--- a/src/components/filter/open-range-filter.tsx
+++ b/src/components/filter/open-range-filter.tsx
@@ -103,8 +103,8 @@ export const OpenRange: FC<
           <div className="flex items-center justify-between">
             <NumberInput
               id="first-input"
-              min={min ?? defaultRange[0]}
-              max={max ?? defaultRange[1]}
+              min={min}
+              max={max}
               decimals={decimals}
               {...inputs?.start}
               step={step}
@@ -120,8 +120,8 @@ export const OpenRange: FC<
               }}
             />
             <NumberInput
-              min={min ?? defaultRange[0]}
-              max={max ?? defaultRange[1]}
+              min={min}
+              max={max}
               decimals={decimals}
               {...inputs?.end}
               step={step}

--- a/src/lib/search-parsers/shared/parsers.ts
+++ b/src/lib/search-parsers/shared/parsers.ts
@@ -42,9 +42,7 @@ export const effectiveBalanceParser = parseAsTuple(
   {
     postParse: sortNumbers,
   }
-)
-  .withDefault([0, 2048 * 3000])
-  .withOptions(defaultSearchOptions)
+).withOptions(defaultSearchOptions)
 
 const bigintTuple = z.tuple([
   z.bigint({ coerce: true }),


### PR DESCRIPTION
## Solves F-explorer-028

## Summary
This PR fixes the accounts Effective Balance (EB) filter so the default state no longer excludes valid accounts.

## Changes
- remove the default `effectiveBalance` range from the shared EB search parser
- keep the accounts EB filter unset by default so the initial state represents "no filter"
- update the shared EB filter component to support parsers without a default value
- keep the EB input lower bound at `0`
- stop deriving `OpenRange` min/max from `defaultRange` for this flow, so the missing parser default does not reintroduce an implicit upper bound

## Why
Previously, the accounts page applied a default EB max value even when the user had not set any filter. That meant the default state could return fewer results than a manually entered higher max, which is incorrect. The default state should show all accounts, and manual values should only narrow results.

## Expected behavior after this change
- opening the accounts page with no EB query param shows all accounts
- the EB filter is only applied after the user explicitly sets a value
- negative EB values are still blocked
- there is no default upper-bound validation for EB inputs

## Validation
- `pnpm typecheck`
- `pnpm eslint src/lib/search-parsers/shared/parsers.ts src/app/_components/shared/filters/effective-balance-filter.tsx src/components/filter/open-range-filter.tsx`
- `prettier --check src/lib/search-parsers/shared/parsers.ts src/app/_components/shared/filters/effective-balance-filter.tsx src/components/filter/open-range-filter.tsx`

## Notes
- full repo checks still show pre-existing warnings unrelated to this change
- this change intentionally removes default upper-bound validation for the EB inputs