### PR TITLE
fix: allow build scripts for esbuild, sharp, unrs-resolver in pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,11 @@
     "initVersion": "7.23.1"
   },
   "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp",
+      "unrs-resolver"
+    ],
     "overrides": {
       "@types/react": "19.2.8",
       "@types/react-dom": "19.2.3"


### PR DESCRIPTION
pnpm v9 blocks build scripts by default — Docker build was failing with ERR_PNPM_IGNORED_BUILDS. Adding onlyBuiltDependencies explicitly approves the native modules that require compilation during install.