### PR TITLE
fix: remove ValidatorRemoved from validator history event filter

### DIFF
--- a/src/lib/search-parsers/events-search-parsers.ts
+++ b/src/lib/search-parsers/events-search-parsers.ts
@@ -27,7 +27,6 @@ export const operatorHistoryEventTypes = [
 
 export const validatorHistoryEventTypes = [
   "ValidatorAdded",
-  "ValidatorRemoved",
   "ValidatorExited",
 ] as const satisfies readonly AccountEventName[]
 


### PR DESCRIPTION
## Summary

- Removes `ValidatorRemoved` from the validator history event filter options
- A removed validator's page returns 404 — the user can never reach the page to apply this filter, making it a dead/misleading option

## Context (QA findings from PR #385)

**Finding 1 — Fixed here:** `ValidatorRemoved` should not appear as an event filter on the validator history page. If a validator has been removed, the validator entity page returns 404, so the filter can never be applied. Showing it implies it's usable, which is incorrect UX.

**Finding 2 — Requires backend investigation:** `ValidatorExited` events are not appearing in the validator history, even for validators confirmed as exited on beaconcha.in (e.g. `0xa3febdee...`). The frontend code correctly includes `ValidatorExited` in `validatorHistoryEventTypes` and the API call targets `events/validator/{publicKey}`. This appears to be the backend API endpoint not returning `ValidatorExited` events — needs investigation on the API side.

## Test plan

- [ ] Open any validator history page → confirm the Event filter only shows `ValidatorAdded` and `ValidatorExited`
- [ ] Confirm no `ValidatorRemoved` option appears in the filter dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)