### PR TITLE
feat: add Balance and Runway columns to clusters table with filters a…

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts"
+import "./.next/types/routes.d.ts"
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts"
+import "./.next/dev/types/routes.d.ts"
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/[network]/cluster/[id]/layout.tsx
+++ b/src/app/[network]/cluster/[id]/layout.tsx
@@ -47,6 +47,7 @@ export default async function Layout({ children, params }: LayoutProps) {
   const network = networkStr as ChainName
 
   const cluster = await getCluster({ id, network }).catch(() => null)
+  console.log("cluster runway:", cluster?.runway)
 
   if (!cluster) {
     return (
@@ -117,6 +118,10 @@ export default async function Layout({ children, params }: LayoutProps) {
           <Stat
             title="Validators"
             content={numberFormatter.format(+cluster.validatorCount)}
+          />
+          <Stat
+            title="Runway (days)"
+            content={cluster.runway != null ? `${cluster.runway}` : "-"}
           />
         </div>
       </Card>

--- a/src/app/[network]/cluster/[id]/layout.tsx
+++ b/src/app/[network]/cluster/[id]/layout.tsx
@@ -47,7 +47,6 @@ export default async function Layout({ children, params }: LayoutProps) {
   const network = networkStr as ChainName
 
   const cluster = await getCluster({ id, network }).catch(() => null)
-  console.log("cluster runway:", cluster?.runway)
 
   if (!cluster) {
     return (

--- a/src/app/_components/clusters/cluster-table-filters.tsx
+++ b/src/app/_components/clusters/cluster-table-filters.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils"
 import { useClustersSearchParams } from "@/hooks/search/use-custom-search-params"
 import { Button } from "@/components/ui/button"
 import { textVariants } from "@/components/ui/text"
+import { BalanceAssetFilter } from "@/app/_components/clusters/filters/balance-asset-filter"
 import { IsLiquidatedFilter } from "@/app/_components/clusters/filters/is-liquidated-filter"
 import { OperatorsFilter } from "@/app/_components/clusters/filters/operators-filter"
 import { StatusFilter } from "@/app/_components/clusters/filters/status-filter"
@@ -67,6 +68,25 @@ export const ClusterTableFilters = ({
           name="Effective Balance"
           searchQueryKey="effectiveBalance"
           parser={clustersSearchFilters.effectiveBalance}
+        />
+        <BalanceAssetFilter />
+        <EffectiveBalanceFilter<ClusterSearchFilterKeys>
+          name="Balance"
+          searchQueryKey="balance"
+          parser={clustersSearchFilters.balance}
+          inputs={{
+            start: { placeholder: "From" },
+            end: { placeholder: "To" },
+          }}
+        />
+        <EffectiveBalanceFilter<ClusterSearchFilterKeys>
+          name="Runway"
+          searchQueryKey="runway"
+          parser={clustersSearchFilters.runway}
+          inputs={{
+            start: { placeholder: "From" },
+            end: { placeholder: "To (days)" },
+          }}
         />
         <StatusFilter />
         <IsLiquidatedFilter />

--- a/src/app/_components/clusters/cluster-table-filters.tsx
+++ b/src/app/_components/clusters/cluster-table-filters.tsx
@@ -14,7 +14,10 @@ import { IsLiquidatedFilter } from "@/app/_components/clusters/filters/is-liquid
 import { OperatorsFilter } from "@/app/_components/clusters/filters/operators-filter"
 import { StatusFilter } from "@/app/_components/clusters/filters/status-filter"
 import { HexFilter } from "@/app/_components/shared/filters/address-filter"
-import { EffectiveBalanceFilter } from "@/app/_components/shared/filters/effective-balance-filter"
+import {
+  EffectiveBalanceFilter,
+  OpenRangeFilter,
+} from "@/app/_components/shared/filters/effective-balance-filter"
 
 export type ClusterTableFiltersProps = {
   hideClusterIdFilter?: boolean
@@ -70,7 +73,7 @@ export const ClusterTableFilters = ({
           parser={clustersSearchFilters.effectiveBalance}
         />
         <BalanceAssetFilter />
-        <EffectiveBalanceFilter<ClusterSearchFilterKeys>
+        <OpenRangeFilter<ClusterSearchFilterKeys>
           name="Balance"
           searchQueryKey="balance"
           parser={clustersSearchFilters.balance}
@@ -79,7 +82,7 @@ export const ClusterTableFilters = ({
             end: { placeholder: "To" },
           }}
         />
-        <EffectiveBalanceFilter<ClusterSearchFilterKeys>
+        <OpenRangeFilter<ClusterSearchFilterKeys>
           name="Runway"
           searchQueryKey="runway"
           parser={clustersSearchFilters.runway}

--- a/src/app/_components/clusters/cluster-table-filters.tsx
+++ b/src/app/_components/clusters/cluster-table-filters.tsx
@@ -75,8 +75,8 @@ export const ClusterTableFilters = ({
         <BalanceAssetFilter />
         <OpenRangeFilter<ClusterSearchFilterKeys>
           name="Balance"
-          searchQueryKey="balance"
-          parser={clustersSearchFilters.balance}
+          searchQueryKey="currentBalance"
+          parser={clustersSearchFilters.currentBalance}
           inputs={{
             start: { placeholder: "From" },
             end: { placeholder: "To" },

--- a/src/app/_components/clusters/clusters-table-columns.tsx
+++ b/src/app/_components/clusters/clusters-table-columns.tsx
@@ -6,7 +6,7 @@ import { type ColumnDef } from "@tanstack/react-table"
 import { formatDistanceToNowStrict } from "date-fns"
 
 import { type Cluster } from "@/types/api"
-import { numberFormatter } from "@/lib/utils/number"
+import { formatETH, formatSSV, numberFormatter } from "@/lib/utils/number"
 import { remove0x, shortenAddress } from "@/lib/utils/strings"
 import { useNetworkParam } from "@/hooks/app/useNetworkParam"
 import { CopyBtn } from "@/components/ui/copy-btn"
@@ -93,6 +93,56 @@ export const clustersTableColumns: ColumnDefWithTitle<Cluster>[] = [
     enableSorting: false,
   },
   {
+    accessorKey: "balance",
+    header: ({ column }) => (
+      <DataTableColumnHeader
+        className="justify-end text-right"
+        column={column}
+        title="Balance"
+      />
+    ),
+    cell: ({ row }) => {
+      const ethBalance = BigInt(row.original.ethBalance || 0)
+      const useEth = ethBalance > 0n || row.original.migrated
+      const value = useEth
+        ? formatETH(ethBalance)
+        : formatSSV(BigInt(row.original.balance || 0))
+      return (
+        <div className="flex items-center justify-end gap-2">
+          <Image
+            src={
+              useEth ? "/images/networks/dark.svg" : "/images/ssvIcons/icon.svg"
+            }
+            alt={useEth ? "ETH" : "SSV"}
+            width={16}
+            height={16}
+            className="object-fit size-4"
+          />
+          <Text variant="body-3-medium" className="text-gray-600">
+            {value}
+          </Text>
+        </div>
+      )
+    },
+  },
+  {
+    accessorKey: "runway",
+    header: ({ column }) => (
+      <DataTableColumnHeader
+        className="justify-end text-right"
+        column={column}
+        title="Runway"
+      />
+    ),
+    cell: ({ row }) => (
+      <div className="flex justify-end">
+        <Text variant="body-3-medium" className="text-gray-600">
+          {row.original.runway != null ? `${row.original.runway}` : "-"}
+        </Text>
+      </div>
+    ),
+  },
+  {
     accessorKey: "effectiveBalance",
     header: ({ column }) => (
       <DataTableColumnHeader
@@ -172,8 +222,9 @@ export const clustersTableDefaultColumnsKeys: ClusterColumnsAccessorKeys[] = [
   "clusterId",
   "ownerAddress",
   "operators",
-  "validatorCount",
+  "runway",
   "effectiveBalance",
+  "validatorCount",
   "active",
 ]
 

--- a/src/app/_components/clusters/clusters-table-columns.tsx
+++ b/src/app/_components/clusters/clusters-table-columns.tsx
@@ -93,7 +93,7 @@ export const clustersTableColumns: ColumnDefWithTitle<Cluster>[] = [
     enableSorting: false,
   },
   {
-    accessorKey: "balance",
+    accessorKey: "currentBalance",
     header: ({ column }) => (
       <DataTableColumnHeader
         className="justify-end text-right"

--- a/src/app/_components/clusters/clusters-table-columns.tsx
+++ b/src/app/_components/clusters/clusters-table-columns.tsx
@@ -102,11 +102,11 @@ export const clustersTableColumns: ColumnDefWithTitle<Cluster>[] = [
       />
     ),
     cell: ({ row }) => {
-      const ethBalance = BigInt(row.original.ethBalance || 0)
-      const useEth = ethBalance > 0n || row.original.migrated
+      const useEth = row.original.migrated
+      const currentBalance = BigInt(row.original.currentBalance || 0)
       const value = useEth
-        ? formatETH(ethBalance)
-        : formatSSV(BigInt(row.original.balance || 0))
+        ? formatETH(currentBalance)
+        : formatSSV(currentBalance)
       return (
         <div className="flex items-center justify-end gap-2">
           <Image
@@ -124,6 +124,7 @@ export const clustersTableColumns: ColumnDefWithTitle<Cluster>[] = [
         </div>
       )
     },
+    enableSorting: true,
   },
   {
     accessorKey: "runway",

--- a/src/app/_components/clusters/filters/balance-asset-filter.tsx
+++ b/src/app/_components/clusters/filters/balance-asset-filter.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import { useClustersSearchParams } from "@/hooks/search/use-custom-search-params"
+import {
+  Command,
+  CommandEmpty,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { FilterButton } from "@/components/filter/filter-button"
+
+const options = [
+  { label: "All", value: null },
+  { label: "ETH", value: "eth" },
+  { label: "SSV", value: "ssv" },
+] as const
+
+export function BalanceAssetFilter() {
+  const { filters, setFilters } = useClustersSearchParams()
+
+  return (
+    <FilterButton
+      name="Balance Asset"
+      isActive={filters.balanceType !== null}
+      onClear={() => setFilters((prev) => ({ ...prev, balanceType: null }))}
+    >
+      <Command>
+        <CommandList className="max-h-none overflow-y-auto">
+          <CommandEmpty>This list is empty.</CommandEmpty>
+          <RadioGroup>
+            {options.map((option) => (
+              <CommandItem
+                key={String(option.value)}
+                className="flex h-10 items-center space-x-2 px-2"
+                onSelect={() =>
+                  setFilters((prev) => ({
+                    ...prev,
+                    balanceType: option.value,
+                  }))
+                }
+              >
+                <RadioGroupItem
+                  checked={filters.balanceType === option.value}
+                  id={String(option.value)}
+                  value={String(option.value)}
+                  className="mr-2"
+                />
+                <span className="flex-1 text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+                  {option.label}
+                </span>
+              </CommandItem>
+            ))}
+          </RadioGroup>
+        </CommandList>
+      </Command>
+    </FilterButton>
+  )
+}

--- a/src/app/_components/shared/filters/effective-balance-filter.tsx
+++ b/src/app/_components/shared/filters/effective-balance-filter.tsx
@@ -6,7 +6,10 @@ import { SingleParserBuilder, useQueryState } from "nuqs"
 import { useDisclosure } from "@/hooks/use-disclosure"
 import { Text } from "@/components/ui/text"
 import { FilterButton } from "@/components/filter/filter-button"
-import { OpenRange } from "@/components/filter/open-range-filter"
+import {
+  OpenRange,
+  type OpenRangeProps,
+} from "@/components/filter/open-range-filter"
 
 type Props<TSearchKey extends string = string> = {
   name: string
@@ -14,11 +17,13 @@ type Props<TSearchKey extends string = string> = {
   parser: SingleParserBuilder<[number, number]> & {
     defaultValue?: [number, number]
   }
+  inputs?: OpenRangeProps["inputs"]
 }
 export function EffectiveBalanceFilter<TSearchKey extends string = string>({
   name,
   searchQueryKey,
   parser,
+  inputs,
 }: Props<TSearchKey>) {
   const popup = useDisclosure()
 
@@ -60,24 +65,26 @@ export function EffectiveBalanceFilter<TSearchKey extends string = string>({
         remove={remove}
         step={1}
         decimals={0}
-        inputs={{
-          start: {
-            placeholder: "From",
-            rightSlot: (
-              <Text variant="body-3-medium" className="text-gray-500">
-                ETH
-              </Text>
-            ),
-          },
-          end: {
-            placeholder: "To",
-            rightSlot: (
-              <Text variant="body-3-medium" className="text-gray-500">
-                ETH
-              </Text>
-            ),
-          },
-        }}
+        inputs={
+          inputs ?? {
+            start: {
+              placeholder: "From",
+              rightSlot: (
+                <Text variant="body-3-medium" className="text-gray-500">
+                  ETH
+                </Text>
+              ),
+            },
+            end: {
+              placeholder: "To",
+              rightSlot: (
+                <Text variant="body-3-medium" className="text-gray-500">
+                  ETH
+                </Text>
+              ),
+            },
+          }
+        }
       />
     </FilterButton>
   )

--- a/src/app/_components/shared/filters/effective-balance-filter.tsx
+++ b/src/app/_components/shared/filters/effective-balance-filter.tsx
@@ -19,7 +19,8 @@ type Props<TSearchKey extends string = string> = {
   }
   inputs?: OpenRangeProps["inputs"]
 }
-export function EffectiveBalanceFilter<TSearchKey extends string = string>({
+
+export function OpenRangeFilter<TSearchKey extends string = string>({
   name,
   searchQueryKey,
   parser,
@@ -65,27 +66,33 @@ export function EffectiveBalanceFilter<TSearchKey extends string = string>({
         remove={remove}
         step={1}
         decimals={0}
-        inputs={
-          inputs ?? {
-            start: {
-              placeholder: "From",
-              rightSlot: (
-                <Text variant="body-3-medium" className="text-gray-500">
-                  ETH
-                </Text>
-              ),
-            },
-            end: {
-              placeholder: "To",
-              rightSlot: (
-                <Text variant="body-3-medium" className="text-gray-500">
-                  ETH
-                </Text>
-              ),
-            },
-          }
-        }
+        inputs={inputs}
       />
     </FilterButton>
   )
+}
+
+const ethInputs: OpenRangeProps["inputs"] = {
+  start: {
+    placeholder: "From",
+    rightSlot: (
+      <Text variant="body-3-medium" className="text-gray-500">
+        ETH
+      </Text>
+    ),
+  },
+  end: {
+    placeholder: "To",
+    rightSlot: (
+      <Text variant="body-3-medium" className="text-gray-500">
+        ETH
+      </Text>
+    ),
+  },
+}
+
+export function EffectiveBalanceFilter<TSearchKey extends string = string>(
+  props: Omit<Props<TSearchKey>, "inputs">
+) {
+  return <OpenRangeFilter {...props} inputs={ethInputs} />
 }

--- a/src/app/_components/validators/validators-table-columns.tsx
+++ b/src/app/_components/validators/validators-table-columns.tsx
@@ -175,13 +175,19 @@ export const validatorColumns: Record<
   createdAt: {
     accessorKey: "createdAt",
     header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="Registered" />
+      <DataTableColumnHeader
+        column={column}
+        title="Registered"
+        className="justify-end text-right"
+      />
     ),
     cell: ({ row }) => (
       <Tooltip content={row.original.created_at} asChild alignOffset={30}>
-        <Text variant="body-3-medium" className="text-gray-600">
-          {getRelativeTime(row.original.created_at)}
-        </Text>
+        <div className="flex justify-end">
+          <Text variant="body-3-medium" className="text-gray-600">
+            {getRelativeTime(row.original.created_at)}
+          </Text>
+        </div>
       </Tooltip>
     ),
     enableSorting: false,

--- a/src/components/filter/range-filter.tsx
+++ b/src/components/filter/range-filter.tsx
@@ -103,8 +103,8 @@ export const Range: FC<ComponentPropsWithoutRef<"form"> & RangeProps> = ({
           <div className="flex items-center justify-between">
             <NumberInput
               id="first-input"
-              min={min || defaultRange[0]}
-              max={max || defaultRange[1]}
+              min={min ?? defaultRange[0]}
+              max={max ?? (defaultRange[1] || undefined)}
               decimals={decimals}
               {...inputs?.start}
               step={step}
@@ -119,8 +119,8 @@ export const Range: FC<ComponentPropsWithoutRef<"form"> & RangeProps> = ({
               }}
             />
             <NumberInput
-              min={min || defaultRange[0]}
-              max={max || defaultRange[1]}
+              min={min ?? defaultRange[0]}
+              max={max ?? (defaultRange[1] || undefined)}
               decimals={decimals}
               {...inputs?.end}
               step={step}

--- a/src/lib/search-parsers/clusters-search-parsers.ts
+++ b/src/lib/search-parsers/clusters-search-parsers.ts
@@ -13,9 +13,11 @@ import { type Cluster } from "@/types/api"
 import { paginationParser } from "@/lib/search-parsers"
 import {
   addressesParser,
+  balanceRangeParser,
   clustersParser,
   defaultSearchOptions,
   getEffectiveBalanceParser,
+  optionalNumberRangeParser,
 } from "@/lib/search-parsers/shared/parsers"
 import { getSortingStateParser, parseAsTuple } from "@/lib/utils/parsers"
 
@@ -35,6 +37,11 @@ export const clustersSearchFilters = {
     }
   ).withOptions(defaultSearchOptions),
   effectiveBalance: getEffectiveBalanceParser({ serializeToGwei: false }),
+  balanceType: parseAsStringEnum(["eth", "ssv"] as const).withOptions(
+    defaultSearchOptions
+  ),
+  balance: balanceRangeParser,
+  runway: optionalNumberRangeParser.withDefault([0, 0]),
   operatorDetails: parseAsBoolean
     .withOptions(defaultSearchOptions)
     .withDefault(true),

--- a/src/lib/search-parsers/clusters-search-parsers.ts
+++ b/src/lib/search-parsers/clusters-search-parsers.ts
@@ -40,7 +40,7 @@ export const clustersSearchFilters = {
   balanceType: parseAsStringEnum(["eth", "ssv"] as const).withOptions(
     defaultSearchOptions
   ),
-  balance: balanceRangeParser,
+  currentBalance: balanceRangeParser,
   runway: optionalNumberRangeParser.withDefault([0, 0]),
   operatorDetails: parseAsBoolean
     .withOptions(defaultSearchOptions)

--- a/src/lib/search-parsers/shared/parsers.ts
+++ b/src/lib/search-parsers/shared/parsers.ts
@@ -1,5 +1,5 @@
 import { createParser, parseAsArrayOf, type Options } from "nuqs/server"
-import { formatGwei, isAddress, parseGwei } from "viem"
+import { formatGwei, formatUnits, isAddress, parseGwei, parseUnits } from "viem"
 import { z } from "zod"
 
 import { sortNumbers } from "@/lib/utils/number"
@@ -36,6 +36,24 @@ export const numberRangeParser = parseAsTuple(
   ...defaultSearchOptions,
   throttleMs: 500,
 })
+
+export const optionalNumberRangeParser = createParser<[number, number]>({
+  parse: (value) => {
+    try {
+      const [a, b] = value.split(",").map(Number)
+      return [a ?? 0, b ?? 0] as [number, number]
+    } catch {
+      return null
+    }
+  },
+  serialize: ([min, max]) => {
+    if (min && max) return `${min},${max}`
+    if (min) return `${min},`
+    if (max) return `,${max}`
+    return ""
+  },
+  eq: (a, b) => a[0] === b[0] && a[1] === b[1],
+}).withOptions({ ...defaultSearchOptions, throttleMs: 500 })
 
 export const effectiveBalanceParser = parseAsTuple(
   z.tuple([z.number({ coerce: true }), z.number({ coerce: true })]),
@@ -89,3 +107,26 @@ export const getEffectiveBalanceParser = ({
     .withDefault([0, 0])
     .withOptions(defaultSearchOptions)
 }
+
+export const balanceRangeParser = createParser<[number, number]>({
+  parse: (value) => {
+    try {
+      const parsed = bigintTuple
+        .parse(value.split(","))
+        .map((v) => Number(formatUnits(v, 18)))
+      return parsed as [number, number]
+    } catch {
+      return null
+    }
+  },
+  serialize: ([_min, _max]) => {
+    const min = _min ? parseUnits(`${_min}`, 18).toString() : ""
+    const max = _max ? parseUnits(`${_max}`, 18).toString() : ""
+    if (min && max) return `${min},${max}`
+    if (min) return `${min},`
+    if (max) return `,${max}`
+    return ""
+  },
+})
+  .withDefault([0, 0])
+  .withOptions({ ...defaultSearchOptions, throttleMs: 500 })

--- a/src/lib/search-parsers/shared/parsers.ts
+++ b/src/lib/search-parsers/shared/parsers.ts
@@ -47,6 +47,7 @@ export const optionalNumberRangeParser = createParser<[number, number]>({
     }
   },
   serialize: ([min, max]) => {
+    // 0 means "no limit" — intentionally falsy so it's omitted from the URL
     if (min && max) return `${min},${max}`
     if (min) return `${min},`
     if (max) return `,${max}`
@@ -96,6 +97,7 @@ export const getEffectiveBalanceParser = ({
       }
     },
     serialize: ([_min, _max]) => {
+      if (_min === 0 && _max === 0) return ""
       const min = serializeToGwei ? parseGwei(`${_min}`).toString() : `${_min}`
       const max = serializeToGwei ? parseGwei(`${_max}`).toString() : `${_max}`
       if (min && max) return `${min},${max}`
@@ -111,8 +113,9 @@ export const getEffectiveBalanceParser = ({
 export const balanceRangeParser = createParser<[number, number]>({
   parse: (value) => {
     try {
+      const parts = value.split(",").map((v) => (v === "" ? "0" : v))
       const parsed = bigintTuple
-        .parse(value.split(","))
+        .parse(parts)
         .map((v) => Number(formatUnits(v, 18)))
       return parsed as [number, number]
     } catch {

--- a/src/types/api/cluster.ts
+++ b/src/types/api/cluster.ts
@@ -25,6 +25,7 @@ export type Cluster<T extends (Operator | number)[] = Operator[]> = {
   ethBalance: string
   active: boolean
   migrated: boolean
+  runway: number
   updatedAt: Date
   createdAt: Date
   operators: T

--- a/src/types/api/cluster.ts
+++ b/src/types/api/cluster.ts
@@ -23,6 +23,7 @@ export type Cluster<T extends (Operator | number)[] = Operator[]> = {
   blockNumber: string
   balance: string
   ethBalance: string
+  currentBalance: string
   active: boolean
   migrated: boolean
   runway: number


### PR DESCRIPTION
…nd sorting

- Add balance (SSV/ETH icon, sortable) and runway (days, sortable) columns
- Balance: ETH icon for migrated clusters or ethBalance > 0, SSV otherwise
- Runway visible by default; Balance hidden by default
- Column order: Cluster ID, Owner, Operators, Balance, Runway, Eff.Balance, Validators, Status
- Add balanceType, balance (wei range), runway range filters to clusters search parsers
- Add BalanceAssetFilter (ETH/SSV radio) and OpenRange-based filters for balance/runway
- Add runway stat to cluster dashboard layout
- Fix range-filter max/min handling when defaultRange is [0, 0]
- Make EffectiveBalanceFilter accept optional inputs prop
- Add balanceRangeParser (decimal to wei) and optionalNumberRangeParser (0 = no limit)
- Right-align numeric columns in validators table