### PR TITLE
feat: add Balance and Runway columns to clusters table with filters a…

### DIFF
--- a/src/app/[network]/cluster/[id]/layout.tsx
+++ b/src/app/[network]/cluster/[id]/layout.tsx
@@ -108,6 +108,10 @@ export default async function Layout({ children, params }: LayoutProps) {
           />
           <ClusterBalanceStat balance={balance} isMigrated={isMigrated} />
           <Stat
+            title="Runway (days)"
+            content={cluster.runway != null ? `${cluster.runway}` : "-"}
+          />
+          <Stat
             title="Effective Balance"
             tooltip="ETH staked across all validators in this cluster"
             content={

--- a/src/app/_components/clusters/cluster-table-filters.tsx
+++ b/src/app/_components/clusters/cluster-table-filters.tsx
@@ -9,11 +9,15 @@ import { cn } from "@/lib/utils"
 import { useClustersSearchParams } from "@/hooks/search/use-custom-search-params"
 import { Button } from "@/components/ui/button"
 import { textVariants } from "@/components/ui/text"
+import { BalanceAssetFilter } from "@/app/_components/clusters/filters/balance-asset-filter"
 import { IsLiquidatedFilter } from "@/app/_components/clusters/filters/is-liquidated-filter"
 import { OperatorsFilter } from "@/app/_components/clusters/filters/operators-filter"
 import { StatusFilter } from "@/app/_components/clusters/filters/status-filter"
 import { HexFilter } from "@/app/_components/shared/filters/address-filter"
-import { EffectiveBalanceFilter } from "@/app/_components/shared/filters/effective-balance-filter"
+import {
+  EffectiveBalanceFilter,
+  OpenRangeFilter,
+} from "@/app/_components/shared/filters/effective-balance-filter"
 
 export type ClusterTableFiltersProps = {
   hideClusterIdFilter?: boolean
@@ -67,6 +71,25 @@ export const ClusterTableFilters = ({
           name="Effective Balance"
           searchQueryKey="effectiveBalance"
           parser={clustersSearchFilters.effectiveBalance}
+        />
+        <BalanceAssetFilter />
+        <OpenRangeFilter<ClusterSearchFilterKeys>
+          name="Balance"
+          searchQueryKey="currentBalance"
+          parser={clustersSearchFilters.currentBalance}
+          inputs={{
+            start: { placeholder: "From" },
+            end: { placeholder: "To" },
+          }}
+        />
+        <OpenRangeFilter<ClusterSearchFilterKeys>
+          name="Runway"
+          searchQueryKey="runway"
+          parser={clustersSearchFilters.runway}
+          inputs={{
+            start: { placeholder: "From" },
+            end: { placeholder: "To (days)" },
+          }}
         />
         <StatusFilter />
         <IsLiquidatedFilter />

--- a/src/app/_components/clusters/clusters-table-columns.tsx
+++ b/src/app/_components/clusters/clusters-table-columns.tsx
@@ -6,7 +6,7 @@ import { type ColumnDef } from "@tanstack/react-table"
 import { formatDistanceToNowStrict } from "date-fns"
 
 import { type Cluster } from "@/types/api"
-import { numberFormatter } from "@/lib/utils/number"
+import { formatETH, formatSSV, numberFormatter } from "@/lib/utils/number"
 import { remove0x, shortenAddress } from "@/lib/utils/strings"
 import { useNetworkParam } from "@/hooks/app/useNetworkParam"
 import { CopyBtn } from "@/components/ui/copy-btn"
@@ -93,6 +93,57 @@ export const clustersTableColumns: ColumnDefWithTitle<Cluster>[] = [
     enableSorting: false,
   },
   {
+    accessorKey: "currentBalance",
+    header: ({ column }) => (
+      <DataTableColumnHeader
+        className="justify-end text-right"
+        column={column}
+        title="Balance"
+      />
+    ),
+    cell: ({ row }) => {
+      const useEth = row.original.migrated
+      const currentBalance = BigInt(row.original.currentBalance || 0)
+      const value = useEth
+        ? formatETH(currentBalance)
+        : formatSSV(currentBalance)
+      return (
+        <div className="flex items-center justify-end gap-2">
+          <Image
+            src={
+              useEth ? "/images/networks/dark.svg" : "/images/ssvIcons/icon.svg"
+            }
+            alt={useEth ? "ETH" : "SSV"}
+            width={16}
+            height={16}
+            className="object-fit size-4"
+          />
+          <Text variant="body-3-medium" className="text-gray-600">
+            {value}
+          </Text>
+        </div>
+      )
+    },
+    enableSorting: true,
+  },
+  {
+    accessorKey: "runway",
+    header: ({ column }) => (
+      <DataTableColumnHeader
+        className="justify-end text-right"
+        column={column}
+        title="Runway (days)"
+      />
+    ),
+    cell: ({ row }) => (
+      <div className="flex justify-end">
+        <Text variant="body-3-medium" className="text-gray-600">
+          {row.original.runway != null ? `${row.original.runway}` : "-"}
+        </Text>
+      </div>
+    ),
+  },
+  {
     accessorKey: "effectiveBalance",
     header: ({ column }) => (
       <DataTableColumnHeader
@@ -155,7 +206,7 @@ export const clustersTableColumns: ColumnDefWithTitle<Cluster>[] = [
   {
     accessorKey: "createdAt",
     header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="Created At" />
+      <DataTableColumnHeader column={column} title="Formation Date" />
     ),
     cell: ({ row }) => (
       <Text variant="body-3-medium" className="text-gray-600">
@@ -172,8 +223,9 @@ export const clustersTableDefaultColumnsKeys: ClusterColumnsAccessorKeys[] = [
   "clusterId",
   "ownerAddress",
   "operators",
-  "validatorCount",
+  "runway",
   "effectiveBalance",
+  "validatorCount",
   "active",
 ]
 

--- a/src/app/_components/clusters/filters/balance-asset-filter.tsx
+++ b/src/app/_components/clusters/filters/balance-asset-filter.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import { useClustersSearchParams } from "@/hooks/search/use-custom-search-params"
+import {
+  Command,
+  CommandEmpty,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { FilterButton } from "@/components/filter/filter-button"
+
+const options = [
+  { label: "All", value: null },
+  { label: "ETH", value: "eth" },
+  { label: "SSV", value: "ssv" },
+] as const
+
+export function BalanceAssetFilter() {
+  const { filters, setFilters } = useClustersSearchParams()
+
+  return (
+    <FilterButton
+      name="Balance Asset"
+      isActive={filters.balanceType !== null}
+      onClear={() =>
+        setFilters((prev) => ({
+          ...prev,
+          balanceType: null,
+        }))
+      }
+    >
+      <Command>
+        <CommandList className="max-h-none overflow-y-auto">
+          <CommandEmpty>This list is empty.</CommandEmpty>
+          <RadioGroup>
+            {options.map((option) => (
+              <CommandItem
+                key={option.label}
+                className="flex h-10 items-center space-x-2 px-2"
+                onSelect={() => {
+                  setFilters((prev) => ({
+                    ...prev,
+                    balanceType: option.value,
+                  }))
+                }}
+              >
+                <RadioGroupItem
+                  checked={filters.balanceType === option.value}
+                  id={option.label}
+                  value={option.label}
+                  className="mr-2"
+                />
+                <span className="flex-1 text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+                  {option.label}
+                </span>
+              </CommandItem>
+            ))}
+          </RadioGroup>
+        </CommandList>
+      </Command>
+    </FilterButton>
+  )
+}

--- a/src/app/_components/shared/filters/effective-balance-filter.tsx
+++ b/src/app/_components/shared/filters/effective-balance-filter.tsx
@@ -6,7 +6,10 @@ import { SingleParserBuilder, useQueryState } from "nuqs"
 import { useDisclosure } from "@/hooks/use-disclosure"
 import { Text } from "@/components/ui/text"
 import { FilterButton } from "@/components/filter/filter-button"
-import { OpenRange } from "@/components/filter/open-range-filter"
+import {
+  OpenRange,
+  type OpenRangeProps,
+} from "@/components/filter/open-range-filter"
 
 type Props<TSearchKey extends string = string> = {
   name: string
@@ -14,11 +17,14 @@ type Props<TSearchKey extends string = string> = {
   parser: SingleParserBuilder<[number, number]> & {
     defaultValue?: [number, number]
   }
+  inputs?: OpenRangeProps["inputs"]
 }
-export function EffectiveBalanceFilter<TSearchKey extends string = string>({
+
+export function OpenRangeFilter<TSearchKey extends string = string>({
   name,
   searchQueryKey,
   parser,
+  inputs,
 }: Props<TSearchKey>) {
   const popup = useDisclosure()
 
@@ -60,25 +66,33 @@ export function EffectiveBalanceFilter<TSearchKey extends string = string>({
         remove={remove}
         step={1}
         decimals={0}
-        inputs={{
-          start: {
-            placeholder: "From",
-            rightSlot: (
-              <Text variant="body-3-medium" className="text-gray-500">
-                ETH
-              </Text>
-            ),
-          },
-          end: {
-            placeholder: "To",
-            rightSlot: (
-              <Text variant="body-3-medium" className="text-gray-500">
-                ETH
-              </Text>
-            ),
-          },
-        }}
+        inputs={inputs}
       />
     </FilterButton>
   )
+}
+
+const ethInputs: OpenRangeProps["inputs"] = {
+  start: {
+    placeholder: "From",
+    rightSlot: (
+      <Text variant="body-3-medium" className="text-gray-500">
+        ETH
+      </Text>
+    ),
+  },
+  end: {
+    placeholder: "To",
+    rightSlot: (
+      <Text variant="body-3-medium" className="text-gray-500">
+        ETH
+      </Text>
+    ),
+  },
+}
+
+export function EffectiveBalanceFilter<TSearchKey extends string = string>(
+  props: Omit<Props<TSearchKey>, "inputs">
+) {
+  return <OpenRangeFilter {...props} inputs={ethInputs} />
 }

--- a/src/app/_components/validators/validators-table-columns.tsx
+++ b/src/app/_components/validators/validators-table-columns.tsx
@@ -175,13 +175,19 @@ export const validatorColumns: Record<
   createdAt: {
     accessorKey: "createdAt",
     header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="Registered" />
+      <DataTableColumnHeader
+        column={column}
+        title="Registered"
+        className="justify-end text-right"
+      />
     ),
     cell: ({ row }) => (
       <Tooltip content={row.original.created_at} asChild alignOffset={30}>
-        <Text variant="body-3-medium" className="text-gray-600">
-          {getRelativeTime(row.original.created_at)}
-        </Text>
+        <div className="flex justify-end">
+          <Text variant="body-3-medium" className="text-gray-600">
+            {getRelativeTime(row.original.created_at)}
+          </Text>
+        </div>
       </Tooltip>
     ),
     enableSorting: false,

--- a/src/components/filter/range-filter.tsx
+++ b/src/components/filter/range-filter.tsx
@@ -103,8 +103,8 @@ export const Range: FC<ComponentPropsWithoutRef<"form"> & RangeProps> = ({
           <div className="flex items-center justify-between">
             <NumberInput
               id="first-input"
-              min={min || defaultRange[0]}
-              max={max || defaultRange[1]}
+              min={min ?? defaultRange[0]}
+              max={max ?? (defaultRange[1] || undefined)}
               decimals={decimals}
               {...inputs?.start}
               step={step}
@@ -119,8 +119,8 @@ export const Range: FC<ComponentPropsWithoutRef<"form"> & RangeProps> = ({
               }}
             />
             <NumberInput
-              min={min || defaultRange[0]}
-              max={max || defaultRange[1]}
+              min={min ?? defaultRange[0]}
+              max={max ?? (defaultRange[1] || undefined)}
               decimals={decimals}
               {...inputs?.end}
               step={step}

--- a/src/lib/search-parsers/clusters-search-parsers.ts
+++ b/src/lib/search-parsers/clusters-search-parsers.ts
@@ -13,9 +13,11 @@ import { type Cluster } from "@/types/api"
 import { paginationParser } from "@/lib/search-parsers"
 import {
   addressesParser,
+  balanceRangeParser,
   clustersParser,
   defaultSearchOptions,
   getEffectiveBalanceParser,
+  optionalNumberRangeParser,
 } from "@/lib/search-parsers/shared/parsers"
 import { getSortingStateParser, parseAsTuple } from "@/lib/utils/parsers"
 
@@ -35,6 +37,11 @@ export const clustersSearchFilters = {
     }
   ).withOptions(defaultSearchOptions),
   effectiveBalance: getEffectiveBalanceParser({ serializeToGwei: false }),
+  balanceType: parseAsStringEnum(["eth", "ssv"] as const).withOptions(
+    defaultSearchOptions
+  ),
+  currentBalance: balanceRangeParser,
+  runway: optionalNumberRangeParser.withDefault([0, 0]),
   operatorDetails: parseAsBoolean
     .withOptions(defaultSearchOptions)
     .withDefault(true),

--- a/src/lib/search-parsers/shared/parsers.ts
+++ b/src/lib/search-parsers/shared/parsers.ts
@@ -1,5 +1,5 @@
 import { createParser, parseAsArrayOf, type Options } from "nuqs/server"
-import { formatGwei, isAddress, parseGwei } from "viem"
+import { formatGwei, formatUnits, isAddress, parseGwei, parseUnits } from "viem"
 import { z } from "zod"
 
 import { sortNumbers } from "@/lib/utils/number"
@@ -36,6 +36,25 @@ export const numberRangeParser = parseAsTuple(
   ...defaultSearchOptions,
   throttleMs: 500,
 })
+
+export const optionalNumberRangeParser = createParser<[number, number]>({
+  parse: (value) => {
+    try {
+      const [a, b] = value.split(",").map(Number)
+      return [a ?? 0, b ?? 0] as [number, number]
+    } catch {
+      return null
+    }
+  },
+  serialize: ([min, max]) => {
+    // 0 means "no limit" — intentionally falsy so it's omitted from the URL
+    if (min && max) return `${min},${max}`
+    if (min) return `${min},`
+    if (max) return `,${max}`
+    return ""
+  },
+  eq: (a, b) => a[0] === b[0] && a[1] === b[1],
+}).withOptions({ ...defaultSearchOptions, throttleMs: 500 })
 
 export const effectiveBalanceParser = parseAsTuple(
   z.tuple([z.number({ coerce: true }), z.number({ coerce: true })]),
@@ -78,6 +97,7 @@ export const getEffectiveBalanceParser = ({
       }
     },
     serialize: ([_min, _max]) => {
+      if (_min === 0 && _max === 0) return ""
       const min = serializeToGwei ? parseGwei(`${_min}`).toString() : `${_min}`
       const max = serializeToGwei ? parseGwei(`${_max}`).toString() : `${_max}`
       if (min && max) return `${min},${max}`
@@ -89,3 +109,27 @@ export const getEffectiveBalanceParser = ({
     .withDefault([0, 0])
     .withOptions(defaultSearchOptions)
 }
+
+export const balanceRangeParser = createParser<[number, number]>({
+  parse: (value) => {
+    try {
+      const parts = value.split(",").map((v) => (v === "" ? "0" : v))
+      const parsed = bigintTuple
+        .parse(parts)
+        .map((v) => Number(formatUnits(v, 18)))
+      return parsed as [number, number]
+    } catch {
+      return null
+    }
+  },
+  serialize: ([_min, _max]) => {
+    const min = _min ? parseUnits(`${_min}`, 18).toString() : ""
+    const max = _max ? parseUnits(`${_max}`, 18).toString() : ""
+    if (min && max) return `${min},${max}`
+    if (min) return `${min},`
+    if (max) return `,${max}`
+    return ""
+  },
+})
+  .withDefault([0, 0])
+  .withOptions({ ...defaultSearchOptions, throttleMs: 500 })

--- a/src/types/api/cluster.ts
+++ b/src/types/api/cluster.ts
@@ -23,8 +23,10 @@ export type Cluster<T extends (Operator | number)[] = Operator[]> = {
   blockNumber: string
   balance: string
   ethBalance: string
+  currentBalance: string
   active: boolean
   migrated: boolean
+  runway: number
   updatedAt: Date
   createdAt: Date
   operators: T


### PR DESCRIPTION
…nd sorting

- Add currentBalance and runway fields to Cluster type
- Add balanceRangeParser (wei<->ETH) and optionalNumberRangeParser
- Fix getEffectiveBalanceParser.serialize to not emit "0,0" for default
- Extract OpenRangeFilter as generic; EffectiveBalanceFilter wraps with ETH inputs
- Add BalanceAssetFilter (All/ETH/SSV radio group)
- Add Balance, BalanceAsset, and Runway filters to cluster table
- Add currentBalance and runway columns with correct order and defaults
- Enable sorting on Balance column
- Add Runway stat to cluster detail layout
- Fix range-filter min/max to use ?? instead of || (handles zero defaultRange)
- Right-align Registered column in validators table