### PR TITLE
fix: support decimal input in balance range filter

### DIFF
--- a/src/app/_components/clusters/cluster-table-filters.tsx
+++ b/src/app/_components/clusters/cluster-table-filters.tsx
@@ -77,6 +77,8 @@ export const ClusterTableFilters = ({
           name="Balance"
           searchQueryKey="currentBalance"
           parser={clustersSearchFilters.currentBalance}
+          step={0.0001}
+          decimals={4}
           inputs={{
             start: { placeholder: "From" },
             end: { placeholder: "To" },

--- a/src/app/_components/shared/filters/effective-balance-filter.tsx
+++ b/src/app/_components/shared/filters/effective-balance-filter.tsx
@@ -18,6 +18,8 @@ type Props<TSearchKey extends string = string> = {
     defaultValue?: [number, number]
   }
   inputs?: OpenRangeProps["inputs"]
+  step?: number
+  decimals?: number
 }
 
 export function OpenRangeFilter<TSearchKey extends string = string>({
@@ -25,6 +27,8 @@ export function OpenRangeFilter<TSearchKey extends string = string>({
   searchQueryKey,
   parser,
   inputs,
+  step = 1,
+  decimals = 0,
 }: Props<TSearchKey>) {
   const popup = useDisclosure()
 
@@ -64,8 +68,8 @@ export function OpenRangeFilter<TSearchKey extends string = string>({
         min={0}
         apply={apply}
         remove={remove}
-        step={1}
-        decimals={0}
+        step={step}
+        decimals={decimals}
         inputs={inputs}
       />
     </FilterButton>

--- a/src/components/ui/number-input.tsx
+++ b/src/components/ui/number-input.tsx
@@ -202,7 +202,7 @@ type NumberInputFC = FC<NumberProps>
 
 const formatNumber = (value: number, decimals: number) => {
   if (isNaN(value)) return "0"
-  return value.toFixed(decimals).replace(/\.0+$/, "")
+  return value.toFixed(decimals).replace(/\.?0+$/, "") || "0"
 }
 
 export const NumberInput: NumberInputFC = forwardRef<


### PR DESCRIPTION
- Add step and decimals props to OpenRangeFilter
- Set step=0.0001, decimals=4 for Balance filter
- Fix formatNumber to strip trailing zeros (0.1000 -> 0.1)