### PR TITLE
fix: use static cache tags for entity event queries to stop memory leak

### DIFF
--- a/.claude/skills/unstable-cache-tags/SKILL.md
+++ b/.claude/skills/unstable-cache-tags/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: unstable-cache-tags
+description: Rule for unstable_cache tags in this repo. Use whenever writing or editing an unstable_cache(...) call, or anything in src/api/*. Tags must be static string literals, never built from params.
+---
+
+# unstable_cache tags must be STATIC
+
+In any `unstable_cache(...)` call, the `tags` array must contain only **static string literals**.
+
+**Never** build a tag from a variable, param, or template literal.
+
+```ts
+// ❌ NEVER — leaks memory. Each unique value adds a permanent entry to Next's
+//    process-global tagsManifest Map, which is never evicted.
+tags: [`validator-events-${params.publicKey}`]
+tags: [`cluster-events-${params.clusterHash}`]
+
+// ✅ ALWAYS — static literal.
+tags: ["validator-events"]
+tags: ["cluster-events"]
+```
+
+Per-entity isolation is already handled by `keyParts` (the cache key), not by tags.
+This caused a production memory leak (PR #413).

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -82,7 +82,11 @@ export const getValidatorEvents = async (
     [JSON.stringify(stringifyBigints(params))],
     {
       revalidate: 30,
-      tags: [`validator-events-${params.publicKey}`],
+      // Static tag — must NOT include the publicKey. A per-entity tag creates an
+      // unbounded number of unique tags that accumulate forever in Next's global
+      // `tagsManifest` Map (never evicted), causing a steady server memory leak.
+      // Per-entity cache isolation is already handled by the keyParts above.
+      tags: ["validator-events"],
     }
   )()
 
@@ -109,7 +113,9 @@ export const getClusterEvents = async (
     [JSON.stringify(stringifyBigints(params))],
     {
       revalidate: 30,
-      tags: [`cluster-events-${params.clusterHash}`],
+      // Static tag — see note on validator-events. A `cluster-events-${hash}` tag
+      // is unbounded and leaks into Next's global tagsManifest Map.
+      tags: ["cluster-events"],
     }
   )()
 
@@ -136,6 +142,8 @@ export const getOperatorHistoryEvents = async (
     [JSON.stringify(stringifyBigints(params))],
     {
       revalidate: 30,
-      tags: [`operator-events-${params.operatorId}`],
+      // Static tag — see note on validator-events. An `operator-events-${id}` tag
+      // is unbounded and leaks into Next's global tagsManifest Map.
+      tags: ["operator-events"],
     }
   )()


### PR DESCRIPTION
## Problem

Production `ssv-explorer` server memory grew ~100–150MB/day, hitting the limit and OOM-restarting every 4–7 days. DevOps pinned the onset precisely: stable for ~80 days, then continuous growth starting at the **2026-05-19 deploy** (`1a8ff1c → 8c065cf`) — the deploy that introduced the validator/cluster/operator **history tabs**.

## Root cause

The event-history queries tagged their `unstable_cache` entries with **per-entity tags**:

```ts
tags: [`validator-events-${params.publicKey}`]   // one unique tag per validator
tags: [`cluster-events-${params.clusterHash}`]   // one unique tag per cluster
tags: [`operator-events-${params.operatorId}`]   // one unique tag per operator
```

Next.js records every tag it sees in a **process-global `Map`** (`tagsManifest` in `next/dist/server/lib/incremental-cache/tags-manifest.external.js` — `const tagsManifest = new Map()`) that is **never evicted**. Each distinct entity visited (every validator/cluster/operator history page hit, including crawlers) added a permanent entry. With tens of thousands of entities, this grows unbounded → the observed leak.

Note: the cache **data** itself was never the problem — that's an LRU bounded at 50MB (`cacheMaxMemorySize` default). Only the **tag-name registry** was unbounded.

## Fix

Use **static tags** instead of per-entity tags:

```ts
tags: ["validator-events"]
tags: ["cluster-events"]
tags: ["operator-events"]
```

This is safe because:
- Per-entity **cache isolation is handled by the cache key** (`keyParts: [JSON.stringify(stringifyBigints(params))]`), which is unchanged — each validator/cluster/operator still gets its own cache entry.
- The app **never calls `revalidateTag`/`revalidatePath`** anywhere, so the unique tags served no functional purpose.
- An audit of all 24 `unstable_cache` tags across the 8 API files confirms every remaining tag is now a static literal — no other dynamic tags exist.

## Verification

- `pnpm typecheck` passes.
- Caching behavior unchanged: 30s `revalidate`, same per-entity isolation via key.
- To confirm in staging: watch RSS over a sustained crawl of validator/cluster/operator history pages — memory should plateau rather than climb linearly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
