### PR TITLE
fix: add request timeout to API client to stop server memory leak

### DIFF
--- a/src/api/api-client.ts
+++ b/src/api/api-client.ts
@@ -1,14 +1,23 @@
 import Axios from "axios"
 
+// Per-request timeout. Without it, a request that connects to an unresponsive
+// upstream but never receives a response hangs forever. In the App Router that
+// keeps the background-revalidation promise — and the whole captured request
+// context (incl. the cached stale response) — referenced by Next's end-of-request
+// `Promise.all(pendingRevalidates)`, so it can never be garbage-collected. Under a
+// flaky backend that accumulates into a steady server-side memory leak. A finite
+// timeout turns every hang into a fast rejection that is caught and freed.
+// Applied at the instance level, axios merges this into every request.
+const REQUEST_TIMEOUT_MS = 15_000
+
 export const api = Axios.create({
+  timeout: REQUEST_TIMEOUT_MS,
   headers: {
     "web-app-source": true,
   },
 })
 
 api.interceptors.response.use(
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   (response) => response.data,
-  // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
   (error) => Promise.reject(error)
 )


### PR DESCRIPTION
## Summary

The `ssv-explorer` server pod leaks memory steadily — it climbs from ~200 MB at startup to the 3 GB limit over ~12 days, gets OOM-killed, restarts, and repeats. This PR addresses the most likely root cause: the shared axios client has **no request timeout**, so a request to an unresponsive backend hangs forever and pins a Next.js request context (and its cached stale response) in memory permanently.

## Symptom

- **Memory Usage (WSS)** for the prod pod grows roughly linearly to the 3 GB limit, then OOM-kills and restarts — a sawtooth that repeats every ~12 days.
- Server logs are dominated by failed background cache revalidations: ~450 `AxiosError: Request failed with status code …`, plus `ECONNRESET` / `socket hang up`. The events backend is erroring heavily.

## Root cause

1. Every entity data fetch goes through `unstable_cache(..., { revalidate: 30 })`. The History tabs feature (#385) added five such cached endpoints across **per-entity dynamic routes** (`/[network]/{validator/[publicKey],cluster/[id],operator/[id],account/[address]}/history`), so there is a very high volume of distinct cached keys and constant background revalidation traffic.
2. The shared axios client (`src/api/api-client.ts`) had **no `timeout`**.
3. When a cache entry goes stale, Next runs the fetch in the background and, at request end, awaits `Promise.all([...Object.values(pendingRevalidates)])` (`next/dist/server/revalidation-utils.js`).
4. If the backend **accepts the connection but never responds**, that `api.get()` never settles (no timeout). The revalidation promise never resolves → the `Promise.all` never resolves → the request's `WorkStore` and the captured stale response can never be garbage-collected.
5. Under a flaky backend this accumulates one pinned request context at a time → the steady server-side memory leak in the graph.

Note: the logs only show the **fast-fail** cases (`ECONNRESET` / `socket hang up`), which are caught and freed. The **hangs** produce no log line — which is exactly how a silent leak behaves.

## Why the earlier "static cache tags" fix (#413) didn't stop it

That fix targeted Next's process-global `tagsManifest`. But in **Next 16.1.3** `tagsManifest` only grows when `revalidateTag` is called (`file-system-cache.js`), which this app never does — so the per-entity tags never actually leaked that manifest. The static-tag change was effectively a no-op against this leak. (It's still a good rule to keep; it just wasn't the cause here.)

## What was ruled out (on the deployed commit)

- `tagsManifest` — only written by `revalidateTag`, never called → bounded.
- `unstable_cache` in-memory store — an `LRUCache(maxMemoryCacheSize)` (~50 MB) → bounded.
- Implicit per-URL tags / `getImplicitTags` — rebuilt per request, not memoized → bounded.
- `IncrementalCache.locks` — deleted after use → bounded.
- App module scope — no growing `Map`/`Set`/array, no server-side subscriptions, no APM/log buffers.

## The fix

Add a per-request `timeout` (15s) to the axios instance. A finite timeout turns every hang into a fast `ECONNABORTED` rejection, which the existing revalidation `.catch` handles → the promise settles → the request context is freed → retained memory stays bounded.

```ts
const REQUEST_TIMEOUT_MS = 15_000
export const api = Axios.create({ timeout: REQUEST_TIMEOUT_MS, headers: { ... } })
```

(Not using an instance-level `AbortSignal.timeout()` — that signal is created once and shared, so it would abort *all* requests after a single fixed delay. Axios's `timeout` is applied per request, which is what we want.)

## How to verify

- **On stage:** deploy and watch the Memory Usage (WSS) slope — it should flatten instead of climbing linearly.
- **Definitive (prod):** take comparison heap snapshots off the live pod (`kill -USR1 1` to enable the inspector, `kubectl port-forward … 9229:9229`, then Chrome → chrome://inspect → two snapshots ~30 min apart) and confirm retained `Promise`/closure/`AxiosError`/response-string counts stop growing.

## Risk

- 15s is generous for these endpoints (responses are typically sub-second); if any legitimately-slow endpoint surfaces false timeouts on stage, bump `REQUEST_TIMEOUT_MS`.
- This is a backend-facing HTTP client that should always have a timeout, so the change is correct hygiene regardless of whether hung revalidations turn out to be the entire story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
