### PR TITLE
fix: order event queries by blockNumber and clean up recent-events URL

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -48,7 +48,7 @@ export const getRecentSSVEvents = async (
     async () => {
       const searchParams = eventsSearchParamsSerializer(params)
       const response = await api.get<PaginatedEventsResponse>(
-        endpoint(params.network, "events", `?${searchParams}`)
+        endpoint(params.network, "events", searchParams)
       )
       return response
     },

--- a/src/app/[network]/operator/[id]/history/page.tsx
+++ b/src/app/[network]/operator/[id]/history/page.tsx
@@ -28,7 +28,7 @@ export default async function Page(props: IndexPageProps) {
     ...search,
     operatorId: id,
     network: network as ChainName,
-    ordering: [{ id: "createdAt", desc: true }],
+    ordering: [{ id: "blockNumber", desc: true }],
   })
 
   return (

--- a/src/app/[network]/overview/page.tsx
+++ b/src/app/[network]/overview/page.tsx
@@ -78,7 +78,7 @@ export default async function Page(props: IndexPageProps) {
 
   const recentSSVEvents = getRecentSSVEvents({
     network,
-    ordering: [{ id: "createdAt", desc: true }],
+    ordering: [{ id: "blockNumber", desc: true }],
   })
 
   const totalOperators = operators?.pagination.total ?? 0


### PR DESCRIPTION
## Summary

Two related fixes to the events queries, following the memory-leak / slow-overview investigation (timeout fix shipped in #420). Branched off latest `stage` (includes #420).

1. **Order event queries by `blockNumber:desc`, not `createdAt:desc`** — the overview "Recent Account Events" card (`getRecentSSVEvents`) and the operator history page (`getOperatorHistoryEvents`) overrode the sort to `createdAt:desc`. Both now use `blockNumber:desc`.
2. **Drop the double-`?` in the recent-events URL** (`getRecentSSVEvents`).

## Why `blockNumber` (verified against `ssv-api` — events controller)

- The backend query DTOs (`event-query.dto.ts`) default ordering to **`blockNumber:DESC`** and only allow `blockNumber` / `createdAt` (the generic route also allows `id`).
- In the subsquid layer (`subsquid.event.queries.ts`), ordering resolves to an `orderBy` enum like `blockNumber_DESC` / `createdAt_DESC`. **`createdAt` is the indexer's wall-clock timestamp**, not on-chain order — a weak sort key (events can share a timestamp; it doesn't track block order), so offset pagination is unstable and the sort is more expensive. `blockNumber:DESC` is the indexed, stable, on-chain ordering the backend already defaults to. So overriding to `createdAt` was both unnecessary and a likely contributor to the slow/failing events queries.

## The anomalies — clearer picture from the controller

- **Operator events are unpaginated by design.** `GET /events/operator/:operatorId` → `getAllByOperatorId(operatorId, ordering, event)` returns a bare `Events[]` and doesn't accept `page`/`perPage` — the backend returns **all** of an operator's events (the frontend `EventsOperatorHistoryTableRoot` paginates client-side). Not changed here, but worth flagging: for a high-activity operator that's a large response to fetch, cache, and serialize on every render. Ordering by `blockNumber` at least makes the subsquid query cheaper.
- **`getRecentSSVEvents` doesn't send `page`/`perPage`** — it's called with only `{ network, ordering }`, so the backend applies its own defaults (page 1, perPage 10, max 1000). That's fine for an overview preview; flagging for clarity.

## The double-`?` fix

`getRecentSSVEvents` built `endpoint(network, "events", \`?${searchParams}\`)` while the nuqs serializer already returns a leading `?`, producing `events??ordering=…`. `urlJoin` normalizes `??` to `?&`, so it wasn't a hard failure — but it's inconsistent with the other four event queries (which pass `searchParams` directly) and is the same class of double-`?` bug the history-tabs PR fixed once before. Now passes `searchParams` directly.

## Scope / risk

- 3 one-line changes; no behavior change beyond sort order and a cleaner URL.
- `lint` + `typecheck` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
